### PR TITLE
Verify row count before cutover

### DIFF
--- a/.github/workflows/shopify-build.yml
+++ b/.github/workflows/shopify-build.yml
@@ -1,0 +1,46 @@
+name: Build and release
+
+on:
+  push:
+    tags:
+      - 'v*-shopify-*'
+
+jobs:
+  build_and_release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Set up fpm
+      shell: bash
+      run: sudo gem install fpm
+
+    - name: Build
+      shell: bash
+      run: ./build.sh
+
+    - name: Get tag name
+      run: echo "SOURCE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+    - name: Checksum
+      shell: bash
+      run: |
+        sha256sum /tmp/gh-ost-release/gh-ost*.deb /tmp/gh-ost-release/gh-ost*.tar.gz /tmp/gh-ost-release/gh-ost*.rpm > gh-ost-${{ env.SOURCE_TAG }}.sha256sum
+        echo "sha256sum:"
+        cat gh-ost-${{ env.SOURCE_TAG }}.sha256sum
+
+    - name: Upload action artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: gh-ost-${{ env.SOURCE_TAG }}
+        path: /tmp/gh-ost-release/gh-ost*
+
+    - name: Create release
+      run: gh release create --prerelease ${{ env.SOURCE_TAG }} /tmp/gh-ost-release/gh-ost*.deb /tmp/gh-ost-release/gh-ost*.tar.gz /tmp/gh-ost-release/gh-ost*.rpm
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README_Shopify.md
+++ b/README_Shopify.md
@@ -1,0 +1,43 @@
+## Development setup for `gh-ost` at Shopify
+
+Requirements:
+- podman, podman machine
+- docker client
+
+Running go tests
+
+```
+dev test
+```
+
+Running `localtests` (integration test suite)
+
+```
+dev localtests
+```
+
+Run a single localtest
+```
+script/build
+
+export PATH="${PATH}:$(pwd)/script"
+./localtests/test.sh -b bin/gh-ost -d swap-uk-uk
+```
+
+## Git workflow
+
+The following branched workflow ensures Shopify can contribute to the upstream repo, while maintaining a stable release channel and the ability to quickly iterate on features and patches to upstream `gh-ost`.
+
+`master`: tracking `github/gh-ost@master`, our release branch where we merge new features and where we cut Shopify releases from using tags following a versioning scheme like `v1.1.7-shopify-1234567`, where the suffix is a short commit SHA. If there are changes in `github/gh-ost@master` that we synced but would not want release temporarily (e.g. until an official tagged release), we can create a new release branch to select the desired commits.
+
+`username/feature-name`: feature branches where we open PRs both to `shopify/gh-ost@master` and `github/gh-ost@master`
+
+Generally, Shopify-specific fixes should be avoided in favor of following the contributing guidelines of `github/gh-ost` and making sure all changes can be merged upstream. This ensures the fork won't diverge and the Shopify-specific build becomes the only long-term option to use it. Don't forget to open a GitHub issue (proposal) in `github/gh-ost` before opening upstream pull requests.
+
+### Releasing gh-ost
+
+1. `git tag v1.1.7-shopify-$(git rev-parse HEAD | cut -c1-7)`
+2. `git push your-shopify-remote --tags`
+3. A GitHub Actions workflow will build and release automatically.
+4. Go to the [releases](https://github.com/Shopify/gh-ost/releases) page, select your release and click the pencil icon and “Generate Release Notes”. This will automatically describe all PRs included, but may not include changes pulled from `master`, which you need to document manually.
+5. Grab the `.deb` file from the [releases](https://github.com/Shopify/gh-ost/releases) page. Find the corresponding checksum in the GitHub Action build logs.

--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,27 @@
+name: gh-ost
+
+env:
+    TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: /var/run/docker.sock
+    TESTCONTAINERS_RYUK_DISABLED: "true"
+
+up:
+  - go:
+        version: "1.23.0"
+  - podman
+  - custom:
+        name: Go Dependencies
+        met?: go mod download
+        meet: echo 'go mod failed to download dependencies'; false
+
+commands:
+  test:
+    desc: Run all the tests.
+    run: |
+      export DOCKER_HOST=unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')
+      script/test
+  localtests:
+    desc: Run localtests.
+    run: |
+      export TEST_MYSQL_IMAGE="mysql:8.4"
+      script/docker-gh-ost-replica-tests up
+      script/docker-gh-ost-replica-tests run

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -152,6 +152,8 @@ type MigrationContext struct {
 	HooksHintToken                      string
 	HooksStatusIntervalSec              int64
 	PanicOnWarnings                     bool
+	VerifyRowCountBeforeCutOver         bool
+	VerifyRowCountBeforeCutOverAccuracy int64
 
 	DropServeSocket bool
 	ServeSocketFile string

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -88,6 +88,9 @@ func main() {
 	flag.BoolVar(&migrationContext.GoogleCloudPlatform, "gcp", false, "set to 'true' when you execute on a 1st generation Google Cloud Platform (GCP).")
 	flag.BoolVar(&migrationContext.AzureMySQL, "azure", false, "set to 'true' when you execute on Azure Database on MySQL.")
 
+	flag.BoolVar(&migrationContext.VerifyRowCountBeforeCutOver, "verify-rowcount-before-cut-over", false, "(with --exact-rowcount), verifies before cut-over that copied rows match the row count")
+	flag.Int64Var(&migrationContext.VerifyRowCountBeforeCutOverAccuracy, "verify-rowcount-before-cut-over-accuracy", 2, "percentage accuracy for verifying row count before cut-over. I.e. how far do we allow the internal row count estimate to be off the actual copied rows")
+
 	executeFlag := flag.Bool("execute", false, "actually execute the alter & migrate the table. Default is noop: do some tests and exit")
 	flag.BoolVar(&migrationContext.TestOnReplica, "test-on-replica", false, "Have the migration run on a replica, not on the master. At the end of migration replication is stopped, and tables are swapped and immediately swap-revert. Replication remains stopped and you can compare the two tables for building trust")
 	flag.BoolVar(&migrationContext.TestOnReplicaSkipReplicaStop, "test-on-replica-skip-replica-stop", false, "When --test-on-replica is enabled, do not issue commands stop replication (requires --test-on-replica)")
@@ -331,6 +334,10 @@ func main() {
 	}
 	if err := migrationContext.SetExponentialBackoffMaxInterval(*exponentialBackoffMaxInterval); err != nil {
 		migrationContext.Log.Errore(err)
+	}
+
+	if !migrationContext.CountTableRows && migrationContext.VerifyRowCountBeforeCutOver {
+		migrationContext.Log.Fatalf("--verify-rowcount-before-cut-over cannot be used without --exact-rowcount")
 	}
 
 	log.Infof("starting gh-ost %+v (git commit: %s)", AppVersion, GitCommit)

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -80,12 +80,17 @@ type Migrator struct {
 	hooksExecutor    *HooksExecutor
 	migrationContext *base.MigrationContext
 
-	firstThrottlingCollected   chan bool
-	ghostTableMigrated         chan bool
-	rowCopyComplete            chan error
-	allEventsUpToLockProcessed chan string
+	firstThrottlingCollected     chan bool
+	ghostTableMigrated           chan bool
+	rowCopyComplete              chan error
+	rowCountComplete             chan error
+	rowCountVerificationComplete chan error
+	allEventsUpToLockProcessed   chan string
 
-	rowCopyCompleteFlag int64
+	rowCopyCompleteFlag              int64
+	rowCountCompleteFlag             int64
+	rowCountVerificationCompleteFlag int64
+
 	// copyRowsQueue should not be buffered; if buffered some non-damaging but
 	//  excessive work happens at the end of the iteration as new copy-jobs arrive before realizing the copy is complete
 	copyRowsQueue    chan tableWriteFunc
@@ -98,14 +103,15 @@ type Migrator struct {
 
 func NewMigrator(context *base.MigrationContext, appVersion string) *Migrator {
 	migrator := &Migrator{
-		appVersion:                 appVersion,
-		hooksExecutor:              NewHooksExecutor(context),
-		migrationContext:           context,
-		parser:                     sql.NewAlterTableParser(),
-		ghostTableMigrated:         make(chan bool),
-		firstThrottlingCollected:   make(chan bool, 3),
-		rowCopyComplete:            make(chan error),
-		allEventsUpToLockProcessed: make(chan string),
+		appVersion:                   appVersion,
+		hooksExecutor:                NewHooksExecutor(context),
+		migrationContext:             context,
+		parser:                       sql.NewAlterTableParser(),
+		ghostTableMigrated:           make(chan bool),
+		firstThrottlingCollected:     make(chan bool, 3),
+		rowCopyComplete:              make(chan error),
+		rowCountVerificationComplete: make(chan error),
+		allEventsUpToLockProcessed:   make(chan string),
 
 		copyRowsQueue:          make(chan tableWriteFunc),
 		applyEventsQueue:       make(chan *applyEventStruct, base.MaxEventsBatchSize),
@@ -189,6 +195,38 @@ func (this *Migrator) consumeRowCopyComplete() {
 	this.migrationContext.MarkRowCopyEndTime()
 	go func() {
 		for err := range this.rowCopyComplete {
+			if err != nil {
+				this.migrationContext.PanicAbort <- err
+			}
+		}
+	}()
+}
+
+// consumeRowCountComplete blocks on the rowCountComplete channel once, and then
+// consumes and drops any further incoming events that may be left hanging.
+func (this *Migrator) consumeRowCountComplete() {
+	if err := <-this.rowCountComplete; err != nil {
+		this.migrationContext.PanicAbort <- err
+	}
+	atomic.StoreInt64(&this.rowCountCompleteFlag, 1)
+	go func() {
+		for err := range this.rowCountComplete {
+			if err != nil {
+				this.migrationContext.PanicAbort <- err
+			}
+		}
+	}()
+}
+
+// consumeRowCountVerificationComplete blocks on the rowCountVerificationComplete channel once,
+// and then consumes and drops any further incoming events that may be left hanging.
+func (this *Migrator) consumeRowCountVerificationComplete() {
+	if err := <-this.rowCountVerificationComplete; err != nil {
+		this.migrationContext.PanicAbort <- err
+	}
+	atomic.StoreInt64(&this.rowCountVerificationCompleteFlag, 1)
+	go func() {
+		for err := range this.rowCountVerificationComplete {
 			if err != nil {
 				this.migrationContext.PanicAbort <- err
 			}
@@ -291,11 +329,13 @@ func (this *Migrator) countTableRows() (err error) {
 
 	countRowsFunc := func(ctx context.Context) error {
 		if err := this.inspector.CountTableRows(ctx); err != nil {
+			this.rowCountComplete <- err
 			return err
 		}
 		if err := this.hooksExecutor.onRowCountComplete(); err != nil {
 			return err
 		}
+		this.rowCountComplete <- nil
 		return nil
 	}
 
@@ -435,6 +475,11 @@ func (this *Migrator) Migrate() (err error) {
 		return err
 	}
 	this.printStatus(ForcePrintStatusRule)
+
+	if this.migrationContext.VerifyRowCountBeforeCutOver {
+		go this.waitForRowCountAndVerify()
+		this.consumeRowCountVerificationComplete()
+	}
 
 	if this.migrationContext.IsCountingTableRows() {
 		this.migrationContext.Log.Info("stopping query for exact row count, because that can accidentally lock out the cut over")
@@ -1205,6 +1250,51 @@ func (this *Migrator) initiateApplier() error {
 	this.applier.WriteChangelogState(string(GhostTableMigrated))
 	go this.applier.InitiateHeartbeat()
 	return nil
+}
+
+func (this *Migrator) waitForRowCountAndVerify() error {
+	this.migrationContext.Log.Debugf("Verifying row count")
+	terminateRowCountVerification := func(err error) error {
+		this.rowCountVerificationComplete <- err
+		return this.migrationContext.Log.Errore(err)
+	}
+	if this.migrationContext.Noop {
+		this.migrationContext.Log.Debugf("Noop operation; not verifying row count")
+		return terminateRowCountVerification(nil)
+	}
+	if this.migrationContext.MigrationRangeMinValues == nil {
+		this.migrationContext.Log.Debugf("No rows found in table. Nothing to verify")
+		return terminateRowCountVerification(nil)
+	}
+
+	if this.migrationContext.IsCountingTableRows() {
+		this.migrationContext.Log.Debugf("Waiting for row count to complete")
+		this.consumeRowCountComplete()
+	}
+
+	this.migrationContext.Log.Debugf("Row count complete")
+
+	if this.migrationContext.UsedRowsEstimateMethod != base.CountRowsEstimate {
+		return terminateRowCountVerification(fmt.Errorf("Row count verification failed. UsedRowsEstimateMethod is %s", this.migrationContext.UsedRowsEstimateMethod))
+	}
+
+	error := this.verifyRowCount()
+
+	return terminateRowCountVerification(error)
+}
+
+func (this *Migrator) verifyRowCount() error {
+	rowsCopied := this.migrationContext.GetTotalRowsCopied()
+	rowsEstimate := atomic.LoadInt64(&this.migrationContext.RowsEstimate)
+	accuracy := this.migrationContext.VerifyRowCountBeforeCutOverAccuracy
+	percentageDiff := int64(math.Round(math.Abs(float64(rowsCopied-rowsEstimate)) / float64(rowsEstimate) * 100))
+
+	if percentageDiff > accuracy {
+		return fmt.Errorf("Row count verification failed. Expected %d rows, but got %d (%d%% difference exceeds allowed %d%%)", rowsEstimate, rowsCopied, percentageDiff, accuracy)
+	} else {
+		this.migrationContext.Log.Debugf("Row count verification successful. Expected %d rows, but got %d (%d%% difference, allowed %d%%)", rowsEstimate, rowsCopied, percentageDiff, accuracy)
+		return nil
+	}
 }
 
 // iterateChunks iterates the existing table rows, and generates a copy task of

--- a/go/logic/migrator_test.go
+++ b/go/logic/migrator_test.go
@@ -448,3 +448,30 @@ func TestMigratorRetryWithExponentialBackoff(t *testing.T) {
 func TestMigrator(t *testing.T) {
 	suite.Run(t, new(MigratorTestSuite))
 }
+
+func TestMigratorVerifyRowCount(t *testing.T) {
+	migrationContext := base.NewMigrationContext()
+	migrationContext.VerifyRowCountBeforeCutOverAccuracy = 5
+	migrationContext.RowsEstimate = 100
+	migrationContext.TotalRowsCopied = 100
+	migrator := NewMigrator(migrationContext, "1.2.3")
+
+	err := migrator.verifyRowCount()
+	assert.NoError(t, err)
+
+	migrationContext.TotalRowsCopied = 95
+	err = migrator.verifyRowCount()
+	assert.NoError(t, err)
+
+	migrationContext.TotalRowsCopied = 105
+	err = migrator.verifyRowCount()
+	assert.NoError(t, err)
+
+	migrationContext.TotalRowsCopied = 94
+	err = migrator.verifyRowCount()
+	assert.Error(t, err)
+
+	migrationContext.TotalRowsCopied = 106
+	err = migrator.verifyRowCount()
+	assert.Error(t, err)
+}

--- a/localtests/fail-update-pk-column/extra_args
+++ b/localtests/fail-update-pk-column/extra_args
@@ -1,0 +1,1 @@
+--verify-rowcount-before-cut-over-accuracy=7

--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -182,6 +182,7 @@ test_single() {
     --storage-engine=${storage_engine} \
     --alter='engine=${storage_engine}' \
     --exact-rowcount \
+    --verify-rowcount-before-cut-over \
     --assume-rbr \
     --initially-drop-old-table \
     --initially-drop-ghost-table \

--- a/localtests/varbinary/extra_args
+++ b/localtests/varbinary/extra_args
@@ -1,0 +1,1 @@
+--verify-rowcount-before-cut-over-accuracy=30


### PR DESCRIPTION
Introduce `verify-rowcount-before-cut-over` flag that prevents migration cutover if expected row count is off by a defined threshold.

These changes are currently missing an upstream issue and pull request.