### PR TITLE
Build and local dev workflow

### DIFF
--- a/.github/workflows/shopify-build.yml
+++ b/.github/workflows/shopify-build.yml
@@ -1,0 +1,46 @@
+name: Build and release
+
+on:
+  push:
+    tags:
+      - 'v*-shopify-*'
+
+jobs:
+  build_and_release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Set up fpm
+      shell: bash
+      run: sudo gem install fpm
+
+    - name: Build
+      shell: bash
+      run: ./build.sh
+
+    - name: Get tag name
+      run: echo "SOURCE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+    - name: Checksum
+      shell: bash
+      run: |
+        sha256sum /tmp/gh-ost-release/gh-ost*.deb /tmp/gh-ost-release/gh-ost*.tar.gz /tmp/gh-ost-release/gh-ost*.rpm > gh-ost-${{ env.SOURCE_TAG }}.sha256sum
+        echo "sha256sum:"
+        cat gh-ost-${{ env.SOURCE_TAG }}.sha256sum
+
+    - name: Upload action artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: gh-ost-${{ env.SOURCE_TAG }}
+        path: /tmp/gh-ost-release/gh-ost*
+
+    - name: Create release
+      run: gh release create --prerelease ${{ env.SOURCE_TAG }} /tmp/gh-ost-release/gh-ost*.deb /tmp/gh-ost-release/gh-ost*.tar.gz /tmp/gh-ost-release/gh-ost*.rpm
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README_Shopify.md
+++ b/README_Shopify.md
@@ -1,0 +1,43 @@
+## Development setup for `gh-ost` at Shopify
+
+Requirements:
+- podman, podman machine
+- docker client
+
+Running go tests
+
+```
+dev test
+```
+
+Running `localtests` (integration test suite)
+
+```
+dev localtests
+```
+
+Run a single localtest
+```
+script/build
+
+export PATH="${PATH}:$(pwd)/script"
+./localtests/test.sh -b bin/gh-ost -d swap-uk-uk
+```
+
+## Git workflow
+
+The following branched workflow ensures Shopify can contribute to the upstream repo, while maintaining a stable release channel and the ability to quickly iterate on features and patches to upstream `gh-ost`.
+
+`master`: tracking `github/gh-ost@master`, our release branch where we merge new features and where we cut Shopify releases from using tags following a versioning scheme like `v1.1.7-shopify-1234567`, where the suffix is a short commit SHA. If there are changes in `github/gh-ost@master` that we synced but would not want release temporarily (e.g. until an official tagged release), we can create a new release branch to select the desired commits.
+
+`username/feature-name`: feature branches where we open PRs both to `shopify/gh-ost@master` and `github/gh-ost@master`
+
+Generally, Shopify-specific fixes should be avoided in favor of following the contributing guidelines of `github/gh-ost` and making sure all changes can be merged upstream. This ensures the fork won't diverge and the Shopify-specific build becomes the only long-term option to use it. Don't forget to open a GitHub issue (proposal) in `github/gh-ost` before opening upstream pull requests.
+
+### Releasing gh-ost
+
+1. `git tag v1.1.7-shopify-$(git rev-parse HEAD | cut -c1-7)`
+2. `git push your-shopify-remote --tags`
+3. A GitHub Actions workflow will build and release automatically.
+4. Go to the [releases](https://github.com/Shopify/gh-ost/releases) page, select your release and click the pencil icon and “Generate Release Notes”. This will automatically describe all PRs included, but may not include changes pulled from `master`, which you need to document manually.
+5. Grab the `.deb` file from the [releases](https://github.com/Shopify/gh-ost/releases) page. Find the corresponding checksum in the GitHub Action build logs.

--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,27 @@
+name: gh-ost
+
+env:
+    TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: /var/run/docker.sock
+    TESTCONTAINERS_RYUK_DISABLED: "true"
+
+up:
+  - go:
+        version: "1.23.0"
+  - podman
+  - custom:
+        name: Go Dependencies
+        met?: go mod download
+        meet: echo 'go mod failed to download dependencies'; false
+
+commands:
+  test:
+    desc: Run all the tests.
+    run: |
+      export DOCKER_HOST=unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')
+      script/test
+  localtests:
+    desc: Run localtests.
+    run: |
+      export TEST_MYSQL_IMAGE="mysql:8.4"
+      script/docker-gh-ost-replica-tests up
+      script/docker-gh-ost-replica-tests run


### PR DESCRIPTION
Inspired by https://github.com/Shopify/gh-ost/pull/6, adds a local dev and release workflow to `master`. Tags will be built and packaged automatically using a new actions workflow. 

I considered keeping the `shopify` branch as a release branch in the fork, but don't think it's necessary. We can create release dedicated release branches if needed (hopefully not).

Reviewers: please tophat the `dev` setup.