### PR TITLE
Verify row count before cutover

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -152,6 +152,8 @@ type MigrationContext struct {
 	HooksHintToken                      string
 	HooksStatusIntervalSec              int64
 	PanicOnWarnings                     bool
+	VerifyRowCountBeforeCutOver         bool
+	VerifyRowCountBeforeCutOverAccuracy int64
 
 	DropServeSocket bool
 	ServeSocketFile string

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -88,6 +88,9 @@ func main() {
 	flag.BoolVar(&migrationContext.GoogleCloudPlatform, "gcp", false, "set to 'true' when you execute on a 1st generation Google Cloud Platform (GCP).")
 	flag.BoolVar(&migrationContext.AzureMySQL, "azure", false, "set to 'true' when you execute on Azure Database on MySQL.")
 
+	flag.BoolVar(&migrationContext.VerifyRowCountBeforeCutOver, "verify-rowcount-before-cut-over", false, "(with --exact-rowcount), verifies before cut-over that copied rows match the row count")
+	flag.Int64Var(&migrationContext.VerifyRowCountBeforeCutOverAccuracy, "verify-rowcount-before-cut-over-accuracy", 2, "percentage accuracy for verifying row count before cut-over. I.e. how far do we allow the internal row count estimate to be off the actual copied rows")
+
 	executeFlag := flag.Bool("execute", false, "actually execute the alter & migrate the table. Default is noop: do some tests and exit")
 	flag.BoolVar(&migrationContext.TestOnReplica, "test-on-replica", false, "Have the migration run on a replica, not on the master. At the end of migration replication is stopped, and tables are swapped and immediately swap-revert. Replication remains stopped and you can compare the two tables for building trust")
 	flag.BoolVar(&migrationContext.TestOnReplicaSkipReplicaStop, "test-on-replica-skip-replica-stop", false, "When --test-on-replica is enabled, do not issue commands stop replication (requires --test-on-replica)")
@@ -331,6 +334,10 @@ func main() {
 	}
 	if err := migrationContext.SetExponentialBackoffMaxInterval(*exponentialBackoffMaxInterval); err != nil {
 		migrationContext.Log.Errore(err)
+	}
+
+	if !migrationContext.CountTableRows && migrationContext.VerifyRowCountBeforeCutOver {
+		migrationContext.Log.Fatalf("--verify-rowcount-before-cut-over cannot be used without --exact-rowcount")
 	}
 
 	log.Infof("starting gh-ost %+v (git commit: %s)", AppVersion, GitCommit)

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -80,12 +80,17 @@ type Migrator struct {
 	hooksExecutor    *HooksExecutor
 	migrationContext *base.MigrationContext
 
-	firstThrottlingCollected   chan bool
-	ghostTableMigrated         chan bool
-	rowCopyComplete            chan error
-	allEventsUpToLockProcessed chan string
+	firstThrottlingCollected     chan bool
+	ghostTableMigrated           chan bool
+	rowCopyComplete              chan error
+	rowCountComplete             chan error
+	rowCountVerificationComplete chan error
+	allEventsUpToLockProcessed   chan string
 
-	rowCopyCompleteFlag int64
+	rowCopyCompleteFlag              int64
+	rowCountCompleteFlag             int64
+	rowCountVerificationCompleteFlag int64
+
 	// copyRowsQueue should not be buffered; if buffered some non-damaging but
 	//  excessive work happens at the end of the iteration as new copy-jobs arrive before realizing the copy is complete
 	copyRowsQueue    chan tableWriteFunc
@@ -98,14 +103,15 @@ type Migrator struct {
 
 func NewMigrator(context *base.MigrationContext, appVersion string) *Migrator {
 	migrator := &Migrator{
-		appVersion:                 appVersion,
-		hooksExecutor:              NewHooksExecutor(context),
-		migrationContext:           context,
-		parser:                     sql.NewAlterTableParser(),
-		ghostTableMigrated:         make(chan bool),
-		firstThrottlingCollected:   make(chan bool, 3),
-		rowCopyComplete:            make(chan error),
-		allEventsUpToLockProcessed: make(chan string),
+		appVersion:                   appVersion,
+		hooksExecutor:                NewHooksExecutor(context),
+		migrationContext:             context,
+		parser:                       sql.NewAlterTableParser(),
+		ghostTableMigrated:           make(chan bool),
+		firstThrottlingCollected:     make(chan bool, 3),
+		rowCopyComplete:              make(chan error),
+		rowCountVerificationComplete: make(chan error),
+		allEventsUpToLockProcessed:   make(chan string),
 
 		copyRowsQueue:          make(chan tableWriteFunc),
 		applyEventsQueue:       make(chan *applyEventStruct, base.MaxEventsBatchSize),
@@ -208,6 +214,38 @@ func (this *Migrator) consumeRowCopyComplete() {
 	}()
 }
 
+// consumeRowCountComplete blocks on the rowCountComplete channel once, and then
+// consumes and drops any further incoming events that may be left hanging.
+func (this *Migrator) consumeRowCountComplete() {
+	if err := <-this.rowCountComplete; err != nil {
+		this.migrationContext.PanicAbort <- err
+	}
+	atomic.StoreInt64(&this.rowCountCompleteFlag, 1)
+	go func() {
+		for err := range this.rowCountComplete {
+			if err != nil {
+				this.migrationContext.PanicAbort <- err
+			}
+		}
+	}()
+}
+
+// consumeRowCountVerificationComplete blocks on the rowCountVerificationComplete channel once,
+// and then consumes and drops any further incoming events that may be left hanging.
+func (this *Migrator) consumeRowCountVerificationComplete() {
+	if err := <-this.rowCountVerificationComplete; err != nil {
+		this.migrationContext.PanicAbort <- err
+	}
+	atomic.StoreInt64(&this.rowCountVerificationCompleteFlag, 1)
+	go func() {
+		for err := range this.rowCountVerificationComplete {
+			if err != nil {
+				this.migrationContext.PanicAbort <- err
+			}
+		}
+	}()
+}
+
 func (this *Migrator) canStopStreaming() bool {
 	return atomic.LoadInt64(&this.migrationContext.CutOverCompleteFlag) != 0
 }
@@ -303,11 +341,13 @@ func (this *Migrator) countTableRows() (err error) {
 
 	countRowsFunc := func(ctx context.Context) error {
 		if err := this.inspector.CountTableRows(ctx); err != nil {
+			this.rowCountComplete <- err
 			return err
 		}
 		if err := this.hooksExecutor.onRowCountComplete(); err != nil {
 			return err
 		}
+		this.rowCountComplete <- nil
 		return nil
 	}
 
@@ -447,6 +487,11 @@ func (this *Migrator) Migrate() (err error) {
 		return err
 	}
 	this.printStatus(ForcePrintStatusRule)
+
+	if this.migrationContext.VerifyRowCountBeforeCutOver {
+		go this.waitForRowCountAndVerify()
+		this.consumeRowCountVerificationComplete()
+	}
 
 	if this.migrationContext.IsCountingTableRows() {
 		this.migrationContext.Log.Info("stopping query for exact row count, because that can accidentally lock out the cut over")
@@ -1217,6 +1262,51 @@ func (this *Migrator) initiateApplier() error {
 	this.applier.WriteChangelogState(string(GhostTableMigrated))
 	go this.applier.InitiateHeartbeat()
 	return nil
+}
+
+func (this *Migrator) waitForRowCountAndVerify() error {
+	this.migrationContext.Log.Debugf("Verifying row count")
+	terminateRowCountVerification := func(err error) error {
+		this.rowCountVerificationComplete <- err
+		return this.migrationContext.Log.Errore(err)
+	}
+	if this.migrationContext.Noop {
+		this.migrationContext.Log.Debugf("Noop operation; not verifying row count")
+		return terminateRowCountVerification(nil)
+	}
+	if this.migrationContext.MigrationRangeMinValues == nil {
+		this.migrationContext.Log.Debugf("No rows found in table. Nothing to verify")
+		return terminateRowCountVerification(nil)
+	}
+
+	if this.migrationContext.IsCountingTableRows() {
+		this.migrationContext.Log.Debugf("Waiting for row count to complete")
+		this.consumeRowCountComplete()
+	}
+
+	this.migrationContext.Log.Debugf("Row count complete")
+
+	if this.migrationContext.UsedRowsEstimateMethod != base.CountRowsEstimate {
+		return terminateRowCountVerification(fmt.Errorf("Row count verification failed. UsedRowsEstimateMethod is %s", this.migrationContext.UsedRowsEstimateMethod))
+	}
+
+	error := this.verifyRowCount()
+
+	return terminateRowCountVerification(error)
+}
+
+func (this *Migrator) verifyRowCount() error {
+	rowsCopied := this.migrationContext.GetTotalRowsCopied()
+	rowsEstimate := atomic.LoadInt64(&this.migrationContext.RowsEstimate)
+	accuracy := this.migrationContext.VerifyRowCountBeforeCutOverAccuracy
+	percentageDiff := int64(math.Round(math.Abs(float64(rowsCopied-rowsEstimate)) / float64(rowsEstimate) * 100))
+
+	if percentageDiff > accuracy {
+		return fmt.Errorf("Row count verification failed. Expected %d rows, but got %d (%d%% difference exceeds allowed %d%%)", rowsEstimate, rowsCopied, percentageDiff, accuracy)
+	} else {
+		this.migrationContext.Log.Debugf("Row count verification successful. Expected %d rows, but got %d (%d%% difference, allowed %d%%)", rowsEstimate, rowsCopied, percentageDiff, accuracy)
+		return nil
+	}
 }
 
 // iterateChunks iterates the existing table rows, and generates a copy task of

--- a/go/logic/migrator_test.go
+++ b/go/logic/migrator_test.go
@@ -573,3 +573,30 @@ func TestMigratorRetryWithExponentialBackoff(t *testing.T) {
 func TestMigrator(t *testing.T) {
 	suite.Run(t, new(MigratorTestSuite))
 }
+
+func TestMigratorVerifyRowCount(t *testing.T) {
+	migrationContext := base.NewMigrationContext()
+	migrationContext.VerifyRowCountBeforeCutOverAccuracy = 5
+	migrationContext.RowsEstimate = 100
+	migrationContext.TotalRowsCopied = 100
+	migrator := NewMigrator(migrationContext, "1.2.3")
+
+	err := migrator.verifyRowCount()
+	assert.NoError(t, err)
+
+	migrationContext.TotalRowsCopied = 95
+	err = migrator.verifyRowCount()
+	assert.NoError(t, err)
+
+	migrationContext.TotalRowsCopied = 105
+	err = migrator.verifyRowCount()
+	assert.NoError(t, err)
+
+	migrationContext.TotalRowsCopied = 94
+	err = migrator.verifyRowCount()
+	assert.Error(t, err)
+
+	migrationContext.TotalRowsCopied = 106
+	err = migrator.verifyRowCount()
+	assert.Error(t, err)
+}

--- a/localtests/fail-update-pk-column/extra_args
+++ b/localtests/fail-update-pk-column/extra_args
@@ -1,0 +1,1 @@
+--verify-rowcount-before-cut-over-accuracy=7

--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -188,6 +188,7 @@ test_single() {
     --storage-engine=${storage_engine} \
     --alter='engine=${storage_engine}' \
     --exact-rowcount \
+    --verify-rowcount-before-cut-over \
     --assume-rbr \
     --initially-drop-old-table \
     --initially-drop-ghost-table \

--- a/localtests/varbinary/extra_args
+++ b/localtests/varbinary/extra_args
@@ -1,0 +1,1 @@
+--verify-rowcount-before-cut-over-accuracy=30


### PR DESCRIPTION
Re-do of https://github.com/Shopify/gh-ost/pull/8 that had an incorrect base branch 🤦‍♂️ 

Introduce `verify-rowcount-before-cut-over` flag that prevents migration cutover if expected row count is off by a defined threshold.

These changes are currently missing an upstream issue and pull request.
