### PR TITLE
Panic if InitiateHeartbeat exhausts retries to avoid looping infinitely

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -552,6 +552,7 @@ func (this *Applier) InitiateHeartbeat() {
 			continue
 		}
 		if err := injectHeartbeat(); err != nil {
+			this.migrationContext.PanicAbort <- fmt.Errorf("injectHeartbeat writing failed %d times, last error: %w", numSuccessiveFailures, err)
 			return
 		}
 	}


### PR DESCRIPTION
Based on experience, if the writer database fails inbeetween the copy & cutover stages (e.g. during cutover pause), the heartbeat writes will fail and stop, then leading to throttled state and an infinite loop of throttler.shouldThrottle().

Since this state is irrecoverable, make the heartbeat writer panic if retries are exhausted, so that the migration can fail and be restarted later.

More details from the investigation can be found in the associated issues:

- https://github.com/github/gh-ost/issues/1569
- https://github.com/Shopify/schema-migrations/issues/3890