### PR TITLE
Improve performance for tables with composite primary keys

### DIFF
--- a/go/sql/builder.go
+++ b/go/sql/builder.go
@@ -281,15 +281,6 @@ func BuildRangeInsertQuery(databaseName, originalTableName, ghostTableName strin
 	sharedColumnsListing := strings.Join(sharedColumns, ", ")
 
 	uniqueKey = EscapeName(uniqueKey)
-	var minRangeComparisonSign = GreaterThanComparisonSign
-	if includeRangeStartValues {
-		minRangeComparisonSign = GreaterThanOrEqualsComparisonSign
-	}
-	rangeStartComparison, rangeExplodedArgs, err := BuildRangeComparison(uniqueKeyColumns.Names(), rangeStartValues, rangeStartArgs, minRangeComparisonSign)
-	if err != nil {
-		return "", explodedArgs, err
-	}
-	explodedArgs = append(explodedArgs, rangeExplodedArgs...)
 	transactionalClause := ""
 	if transactionalTable {
 		if noWait {
@@ -298,6 +289,26 @@ func BuildRangeInsertQuery(databaseName, originalTableName, ghostTableName strin
 			transactionalClause = "lock in share mode"
 		}
 	}
+	var minRangeComparisonSign = GreaterThanComparisonSign
+	if includeRangeStartValues {
+		minRangeComparisonSign = GreaterThanOrEqualsComparisonSign
+	}
+
+	if uniqueKeyColumns.Len() == 2 {
+		return buildRangeInsertQueryTwoColumn(
+			databaseName, originalTableName, ghostTableName,
+			sharedColumnsListing, mappedSharedColumnsListing,
+			uniqueKey, uniqueKeyColumns,
+			rangeStartValues, rangeEndValues,
+			rangeStartArgs, rangeEndArgs,
+			minRangeComparisonSign, transactionalClause,
+		)
+	}
+	rangeStartComparison, rangeExplodedArgs, err := BuildRangeComparison(uniqueKeyColumns.Names(), rangeStartValues, rangeStartArgs, minRangeComparisonSign)
+	if err != nil {
+		return "", explodedArgs, err
+	}
+	explodedArgs = append(explodedArgs, rangeExplodedArgs...)
 	rangeEndComparison, rangeExplodedArgs, err := BuildRangeComparison(uniqueKeyColumns.Names(), rangeEndValues, rangeEndArgs, LessThanOrEqualsComparisonSign)
 	if err != nil {
 		return "", explodedArgs, err
@@ -323,6 +334,74 @@ func BuildRangeInsertQuery(databaseName, originalTableName, ghostTableName strin
 	return result, explodedArgs, nil
 }
 
+func sameFirstColumnValue(rangeStartArgs, rangeEndArgs []interface{}) bool {
+	return fmt.Sprintf("%v", rangeStartArgs[0]) == fmt.Sprintf("%v", rangeEndArgs[0])
+}
+
+func buildRangeInsertQueryTwoColumn(
+	databaseName, originalTableName, ghostTableName string,
+	sharedColumnsListing, mappedSharedColumnsListing string,
+	uniqueKey string,
+	uniqueKeyColumns *ColumnList,
+	rangeStartValues, rangeEndValues []string,
+	rangeStartArgs, rangeEndArgs []interface{},
+	minRangeComparisonSign ValueComparisonSign,
+	transactionalClause string,
+) (result string, explodedArgs []interface{}, err error) {
+	cols := uniqueKeyColumns.Columns()
+	col1Name := EscapeName(cols[0].Name)
+	col2Name := EscapeName(cols[1].Name)
+	col1StartVal := rangeStartValues[0]
+	col2StartVal := rangeStartValues[1]
+	col1EndVal := rangeEndValues[0]
+	col2EndVal := rangeEndValues[1]
+	col2StartOp := string(minRangeComparisonSign)
+	fromClause := fmt.Sprintf("%s.%s force index (%s)", databaseName, originalTableName, uniqueKey)
+
+	if sameFirstColumnValue(rangeStartArgs, rangeEndArgs) {
+		result = fmt.Sprintf(`
+			insert /* gh-ost %s.%s */ ignore
+			into
+			  %s.%s
+				(%s)
+			(
+				select %s
+				from
+				  %s.%s
+				force index (%s)
+					where (%s = %s and %s %s %s and %s <= %s)
+					%s
+			)`,
+			databaseName, originalTableName,
+			databaseName, ghostTableName, mappedSharedColumnsListing,
+			sharedColumnsListing,
+			databaseName, originalTableName, uniqueKey,
+			col1Name, col1StartVal, col2Name, col2StartOp, col2StartVal, col2Name, col2EndVal,
+			transactionalClause,
+		)
+		explodedArgs = append(explodedArgs, rangeStartArgs[0], rangeStartArgs[1], rangeEndArgs[1])
+		return result, explodedArgs, nil
+	}
+
+	part1, part2, part3, explodedArgs := buildTwoColumnUnionParts(
+		sharedColumnsListing, fromClause,
+		col1Name, col2Name,
+		col1StartVal, col2StartVal, col1EndVal, col2EndVal,
+		col2StartOp, transactionalClause,
+		rangeStartArgs, rangeEndArgs,
+	)
+
+	result = fmt.Sprintf(`
+		insert /* gh-ost %s.%s */ ignore
+		into %s.%s (%s)
+		(%s union all %s union all %s)`,
+		databaseName, originalTableName,
+		databaseName, ghostTableName, mappedSharedColumnsListing,
+		part1, part2, part3,
+	)
+	return result, explodedArgs, nil
+}
+
 func BuildRangeInsertPreparedQuery(databaseName, originalTableName, ghostTableName string, sharedColumns []string, mappedSharedColumns []string, uniqueKey string, uniqueKeyColumns *ColumnList, rangeStartArgs, rangeEndArgs []interface{}, includeRangeStartValues bool, transactionalTable bool, noWait bool) (result string, explodedArgs []interface{}, err error) {
 	rangeStartValues := buildColumnsPreparedValues(uniqueKeyColumns)
 	rangeEndValues := buildColumnsPreparedValues(uniqueKeyColumns)
@@ -340,6 +419,11 @@ func BuildUniqueKeyRangeEndPreparedQueryViaOffset(databaseName, tableName string
 	if includeRangeStartValues {
 		startRangeComparisonSign = GreaterThanOrEqualsComparisonSign
 	}
+
+	if uniqueKeyColumns.Len() == 2 {
+		return buildUniqueKeyRangeEndTwoColumnViaOffset(databaseName, tableName, uniqueKeyColumns, rangeStartArgs, rangeEndArgs, chunkSize, startRangeComparisonSign, hint)
+	}
+
 	rangeStartComparison, rangeExplodedArgs, err := BuildRangePreparedComparison(uniqueKeyColumns, rangeStartArgs, startRangeComparisonSign)
 	if err != nil {
 		return "", explodedArgs, err
@@ -393,6 +477,11 @@ func BuildUniqueKeyRangeEndPreparedQueryViaTemptable(databaseName, tableName str
 	if includeRangeStartValues {
 		startRangeComparisonSign = GreaterThanOrEqualsComparisonSign
 	}
+
+	if uniqueKeyColumns.Len() == 2 {
+		return buildUniqueKeyRangeEndTwoColumnViaTemptable(databaseName, tableName, uniqueKeyColumns, rangeStartArgs, rangeEndArgs, chunkSize, startRangeComparisonSign, hint)
+	}
+
 	rangeStartComparison, rangeExplodedArgs, err := BuildRangePreparedComparison(uniqueKeyColumns, rangeStartArgs, startRangeComparisonSign)
 	if err != nil {
 		return "", explodedArgs, err
@@ -438,6 +527,200 @@ func BuildUniqueKeyRangeEndPreparedQueryViaTemptable(databaseName, tableName str
 		rangeStartComparison, rangeEndComparison,
 		strings.Join(uniqueKeyColumnAscending, ", "), chunkSize,
 		strings.Join(uniqueKeyColumnDescending, ", "),
+	)
+	return result, explodedArgs, nil
+}
+
+type twoColumnRangeMeta struct {
+	col1Name, col2Name string
+	col1Val, col2Val   string
+	orderByAsc         string
+	orderByDesc        string
+}
+
+func newTwoColumnRangeMeta(uniqueKeyColumns *ColumnList) twoColumnRangeMeta {
+	colVals := buildColumnsPreparedValues(uniqueKeyColumns)
+	cols := uniqueKeyColumns.Columns()
+	col1Name := EscapeName(cols[0].Name)
+	col2Name := EscapeName(cols[1].Name)
+	col1Asc := fmt.Sprintf("%s asc", col1Name)
+	col2Asc := fmt.Sprintf("%s asc", col2Name)
+	col1Desc := fmt.Sprintf("%s desc", col1Name)
+	col2Desc := fmt.Sprintf("%s desc", col2Name)
+	if cols[0].Type == EnumColumnType {
+		col1Asc = fmt.Sprintf("concat(%s) asc", col1Name)
+		col1Desc = fmt.Sprintf("concat(%s) desc", col1Name)
+	}
+	if cols[1].Type == EnumColumnType {
+		col2Asc = fmt.Sprintf("concat(%s) asc", col2Name)
+		col2Desc = fmt.Sprintf("concat(%s) desc", col2Name)
+	}
+	return twoColumnRangeMeta{
+		col1Name:    col1Name,
+		col2Name:    col2Name,
+		col1Val:     colVals[0],
+		col2Val:     colVals[1],
+		orderByAsc:  col1Asc + ", " + col2Asc,
+		orderByDesc: col1Desc + ", " + col2Desc,
+	}
+}
+
+func buildTwoColumnUnionParts(
+	selectClause, fromClause string,
+	col1Name, col2Name string,
+	col1StartVal, col2StartVal, col1EndVal, col2EndVal string,
+	col2StartOp, partSuffix string,
+	rangeStartArgs, rangeEndArgs []interface{},
+) (part1, part2, part3 string, explodedArgs []interface{}) {
+	part1 = fmt.Sprintf(
+		`(select %s from %s where %s = %s and %s %s %s %s)`,
+		selectClause, fromClause,
+		col1Name, col1StartVal, col2Name, col2StartOp, col2StartVal,
+		partSuffix,
+	)
+	explodedArgs = append(explodedArgs, rangeStartArgs[0], rangeStartArgs[1])
+
+	part2 = fmt.Sprintf(
+		`(select %s from %s where %s > %s and %s < %s %s)`,
+		selectClause, fromClause,
+		col1Name, col1StartVal, col1Name, col1EndVal,
+		partSuffix,
+	)
+	explodedArgs = append(explodedArgs, rangeStartArgs[0], rangeEndArgs[0])
+
+	part3 = fmt.Sprintf(
+		`(select %s from %s where %s = %s and %s <= %s %s)`,
+		selectClause, fromClause,
+		col1Name, col1EndVal, col2Name, col2EndVal,
+		partSuffix,
+	)
+	explodedArgs = append(explodedArgs, rangeEndArgs[0], rangeEndArgs[1])
+	return
+}
+
+func buildUniqueKeyRangeEndTwoColumnViaOffset(
+	databaseName, tableName string,
+	uniqueKeyColumns *ColumnList,
+	rangeStartArgs, rangeEndArgs []interface{},
+	chunkSize int64,
+	startRangeComparisonSign ValueComparisonSign,
+	hint string,
+) (result string, explodedArgs []interface{}, err error) {
+	m := newTwoColumnRangeMeta(uniqueKeyColumns)
+	col2StartOp := string(startRangeComparisonSign)
+	selectClause := m.col1Name + ", " + m.col2Name
+	fromClause := databaseName + "." + tableName
+	partSuffix := fmt.Sprintf("order by %s limit %d", m.orderByAsc, chunkSize)
+
+	if sameFirstColumnValue(rangeStartArgs, rangeEndArgs) {
+		result = fmt.Sprintf(`
+			select /* gh-ost %s.%s %s */
+				%s, %s
+			from
+				%s.%s
+			where
+				(%s = %s and %s %s %s and %s <= %s)
+			order by
+				%s
+			limit 1
+			offset %d`,
+			databaseName, tableName, hint,
+			m.col1Name, m.col2Name,
+			databaseName, tableName,
+			m.col1Name, m.col1Val, m.col2Name, col2StartOp, m.col2Val, m.col2Name, m.col2Val,
+			m.orderByAsc,
+			chunkSize-1,
+		)
+		explodedArgs = append(explodedArgs, rangeStartArgs[0], rangeStartArgs[1], rangeEndArgs[1])
+		return result, explodedArgs, nil
+	}
+
+	part1, part2, part3, explodedArgs := buildTwoColumnUnionParts(
+		selectClause, fromClause,
+		m.col1Name, m.col2Name,
+		m.col1Val, m.col2Val, m.col1Val, m.col2Val,
+		col2StartOp, partSuffix,
+		rangeStartArgs, rangeEndArgs,
+	)
+
+	result = fmt.Sprintf(`
+		select /* gh-ost %s.%s %s */
+			%s, %s
+		from
+			(%s union all %s union all %s) t
+		order by
+			%s
+		limit 1
+		offset %d`,
+		databaseName, tableName, hint,
+		m.col1Name, m.col2Name,
+		part1, part2, part3,
+		m.orderByAsc,
+		chunkSize-1,
+	)
+	return result, explodedArgs, nil
+}
+
+func buildUniqueKeyRangeEndTwoColumnViaTemptable(
+	databaseName, tableName string,
+	uniqueKeyColumns *ColumnList,
+	rangeStartArgs, rangeEndArgs []interface{},
+	chunkSize int64,
+	startRangeComparisonSign ValueComparisonSign,
+	hint string,
+) (result string, explodedArgs []interface{}, err error) {
+	m := newTwoColumnRangeMeta(uniqueKeyColumns)
+	col2StartOp := string(startRangeComparisonSign)
+	selectClause := m.col1Name + ", " + m.col2Name
+	fromClause := databaseName + "." + tableName
+	partSuffix := fmt.Sprintf("order by %s limit %d", m.orderByAsc, chunkSize)
+
+	if sameFirstColumnValue(rangeStartArgs, rangeEndArgs) {
+		result = fmt.Sprintf(`
+			select /* gh-ost %s.%s %s */ %s, %s
+			from (
+				select %s, %s
+				from %s.%s
+				where (%s = %s and %s %s %s and %s <= %s)
+				order by %s
+				limit %d
+			) select_osc_chunk
+			order by %s
+			limit 1`,
+			databaseName, tableName, hint, m.col1Name, m.col2Name,
+			m.col1Name, m.col2Name,
+			databaseName, tableName,
+			m.col1Name, m.col1Val, m.col2Name, col2StartOp, m.col2Val, m.col2Name, m.col2Val,
+			m.orderByAsc, chunkSize,
+			m.orderByDesc,
+		)
+		explodedArgs = append(explodedArgs, rangeStartArgs[0], rangeStartArgs[1], rangeEndArgs[1])
+		return result, explodedArgs, nil
+	}
+
+	part1, part2, part3, explodedArgs := buildTwoColumnUnionParts(
+		selectClause, fromClause,
+		m.col1Name, m.col2Name,
+		m.col1Val, m.col2Val, m.col1Val, m.col2Val,
+		col2StartOp, partSuffix,
+		rangeStartArgs, rangeEndArgs,
+	)
+
+	result = fmt.Sprintf(`
+		select /* gh-ost %s.%s %s */ %s, %s
+		from (
+			select %s, %s
+			from (%s union all %s union all %s) t
+			order by %s
+			limit %d
+		) select_osc_chunk
+		order by %s
+		limit 1`,
+		databaseName, tableName, hint, m.col1Name, m.col2Name,
+		m.col1Name, m.col2Name,
+		part1, part2, part3,
+		m.orderByAsc, chunkSize,
+		m.orderByDesc,
 	)
 	return result, explodedArgs, nil
 }

--- a/go/sql/builder.go
+++ b/go/sql/builder.go
@@ -349,6 +349,20 @@ func buildRangeInsertQueryTwoColumn(
 	transactionalClause string,
 ) (result string, explodedArgs []interface{}, err error) {
 	cols := uniqueKeyColumns.Columns()
+
+	if len(cols) != len(rangeStartValues) {
+		return "", explodedArgs, fmt.Errorf("got %d columns but %d rangeStartValues in buildRangeInsertQueryTwoColumn", len(cols), len(rangeStartValues))
+	}
+	if len(cols) != len(rangeEndValues) {
+		return "", explodedArgs, fmt.Errorf("got %d columns but %d rangeEndValues in buildRangeInsertQueryTwoColumn", len(cols), len(rangeEndValues))
+	}
+	if len(cols) != len(rangeStartArgs) {
+		return "", explodedArgs, fmt.Errorf("got %d columns but %d rangeStartArgs in buildRangeInsertQueryTwoColumn", len(cols), len(rangeStartArgs))
+	}
+	if len(cols) != len(rangeEndArgs) {
+		return "", explodedArgs, fmt.Errorf("got %d columns but %d rangeEndArgs in buildRangeInsertQueryTwoColumn", len(cols), len(rangeEndArgs))
+	}
+
 	col1Name := EscapeName(cols[0].Name)
 	col2Name := EscapeName(cols[1].Name)
 	col1StartVal := rangeStartValues[0]

--- a/go/sql/builder.go
+++ b/go/sql/builder.go
@@ -394,7 +394,7 @@ func buildRangeInsertQueryTwoColumn(
 	result = fmt.Sprintf(`
 		insert /* gh-ost %s.%s */ ignore
 		into %s.%s (%s)
-		(%s union all %s union all %s)`,
+		%s union all %s union all %s`,
 		databaseName, originalTableName,
 		databaseName, ghostTableName, mappedSharedColumnsListing,
 		part1, part2, part3,

--- a/go/sql/builder_test.go
+++ b/go/sql/builder_test.go
@@ -213,6 +213,99 @@ func TestBuildRangeInsertQuery(t *testing.T) {
 		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
 		require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
 	}
+	{
+		// Same first-column value → single range query (no UNION needed).
+		uniqueKey := "name_position_uidx"
+		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
+		rangeStartValues := []string{"@v1s", "@v2s"}
+		rangeEndValues := []string{"@v1e", "@v2e"}
+		rangeStartArgs := []interface{}{3, 17}
+		rangeEndArgs := []interface{}{3, 117}
+
+		query, explodedArgs, err := BuildRangeInsertQuery(databaseName, originalTableName, ghostTableName, sharedColumns, sharedColumns, uniqueKey, uniqueKeyColumns, rangeStartValues, rangeEndValues, rangeStartArgs, rangeEndArgs, true, true, true)
+		require.NoError(t, err)
+		expected := `
+			insert /* gh-ost mydb.tbl */ ignore
+			into
+				mydb.ghost
+				(id, name, position)
+			(
+				select id, name, position
+				from
+					mydb.tbl
+				force index (name_position_uidx)
+					where (name = @v1s and position >= @v2s and position <= @v2e)
+					for share nowait
+			)`
+		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
+		require.Equal(t, []interface{}{3, 17, 117}, explodedArgs)
+	}
+	{
+		// includeRangeStartValues=false → exclusive start (col2 uses >, not >=).
+		uniqueKey := "name_position_uidx"
+		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
+		rangeStartValues := []string{"@v1s", "@v2s"}
+		rangeEndValues := []string{"@v1e", "@v2e"}
+		rangeStartArgs := []interface{}{3, 17}
+		rangeEndArgs := []interface{}{103, 117}
+
+		query, explodedArgs, err := BuildRangeInsertQuery(databaseName, originalTableName, ghostTableName, sharedColumns, sharedColumns, uniqueKey, uniqueKeyColumns, rangeStartValues, rangeEndValues, rangeStartArgs, rangeEndArgs, false, true, true)
+		require.NoError(t, err)
+		expected := `
+			insert /* gh-ost mydb.tbl */ ignore
+			into mydb.ghost (id, name, position)
+			((select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1s and position > @v2s for share nowait)
+			union all
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name > @v1s and name < @v1e for share nowait)
+			union all
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1e and position <= @v2e for share nowait))`
+		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
+		require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
+	}
+	{
+		// transactionalTable=false → no locking clause on UNION subqueries.
+		uniqueKey := "name_position_uidx"
+		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
+		rangeStartValues := []string{"@v1s", "@v2s"}
+		rangeEndValues := []string{"@v1e", "@v2e"}
+		rangeStartArgs := []interface{}{3, 17}
+		rangeEndArgs := []interface{}{103, 117}
+
+		query, explodedArgs, err := BuildRangeInsertQuery(databaseName, originalTableName, ghostTableName, sharedColumns, sharedColumns, uniqueKey, uniqueKeyColumns, rangeStartValues, rangeEndValues, rangeStartArgs, rangeEndArgs, true, false, false)
+		require.NoError(t, err)
+		expected := `
+			insert /* gh-ost mydb.tbl */ ignore
+			into mydb.ghost (id, name, position)
+			((select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1s and position >= @v2s )
+			union all
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name > @v1s and name < @v1e )
+			union all
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1e and position <= @v2e ))`
+		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
+		require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
+	}
+	{
+		// transactionalTable=true, noWait=false → "lock in share mode" on UNION subqueries.
+		uniqueKey := "name_position_uidx"
+		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
+		rangeStartValues := []string{"@v1s", "@v2s"}
+		rangeEndValues := []string{"@v1e", "@v2e"}
+		rangeStartArgs := []interface{}{3, 17}
+		rangeEndArgs := []interface{}{103, 117}
+
+		query, explodedArgs, err := BuildRangeInsertQuery(databaseName, originalTableName, ghostTableName, sharedColumns, sharedColumns, uniqueKey, uniqueKeyColumns, rangeStartValues, rangeEndValues, rangeStartArgs, rangeEndArgs, true, true, false)
+		require.NoError(t, err)
+		expected := `
+			insert /* gh-ost mydb.tbl */ ignore
+			into mydb.ghost (id, name, position)
+			((select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1s and position >= @v2s lock in share mode)
+			union all
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name > @v1s and name < @v1e lock in share mode)
+			union all
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1e and position <= @v2e lock in share mode))`
+		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
+		require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
+	}
 }
 
 func TestBuildRangeInsertQueryRenameMap(t *testing.T) {
@@ -296,6 +389,31 @@ func TestBuildRangeInsertPreparedQuery(t *testing.T) {
 			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = ? and position <= ? for share nowait))`
 		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
 		require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
+	}
+	{
+		// Same first-column value → single range query (no UNION needed).
+		uniqueKey := "name_position_uidx"
+		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
+		rangeStartArgs := []interface{}{3, 17}
+		rangeEndArgs := []interface{}{3, 117}
+
+		query, explodedArgs, err := BuildRangeInsertPreparedQuery(databaseName, originalTableName, ghostTableName, sharedColumns, sharedColumns, uniqueKey, uniqueKeyColumns, rangeStartArgs, rangeEndArgs, true, true, true)
+		require.NoError(t, err)
+		expected := `
+			insert /* gh-ost mydb.tbl */ ignore
+			into
+				mydb.ghost
+				(id, name, position)
+			(
+				select id, name, position
+				from
+					mydb.tbl
+				force index (name_position_uidx)
+					where (name = ? and position >= ? and position <= ?)
+					for share nowait
+			)`
+		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
+		require.Equal(t, []interface{}{3, 17, 117}, explodedArgs)
 	}
 }
 
@@ -403,6 +521,141 @@ func TestBuildUniqueKeyRangeEndPreparedQueryViaTemptable(t *testing.T) {
 		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
 		require.Equal(t, []interface{}{3, 17, 117}, explodedArgs)
 	}
+}
+
+func TestBuildUniqueKeyRangeEndPreparedQueryTwoColumnEnum(t *testing.T) {
+	databaseName := "mydb"
+	originalTableName := "tbl"
+	var chunkSize int64 = 500
+	{
+		// First key column is an enum → ORDER BY must wrap it with concat() so MySQL
+		// sorts by the enum's text label rather than its internal numeric position.
+		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
+		uniqueKeyColumns.SetColumnType("name", EnumColumnType)
+		rangeStartArgs := []interface{}{"a", 17}
+		rangeEndArgs := []interface{}{"z", 117}
+
+		query, _, err := BuildUniqueKeyRangeEndPreparedQueryViaOffset(databaseName, originalTableName, uniqueKeyColumns, rangeStartArgs, rangeEndArgs, chunkSize, false, "test")
+		require.NoError(t, err)
+		expected := `
+			select /* gh-ost mydb.tbl test */
+				name, position
+			from
+				((select name, position from mydb.tbl where name = ? and position > ? order by concat(name) asc, position asc limit 500)
+				union all
+				(select name, position from mydb.tbl where name > ? and name < ? order by concat(name) asc, position asc limit 500)
+				union all
+				(select name, position from mydb.tbl where name = ? and position <= ? order by concat(name) asc, position asc limit 500)) t
+			order by
+				concat(name) asc, position asc
+			limit 1
+			offset 499`
+		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
+	}
+	{
+		// Second key column is an enum → its asc/desc clauses get concat() too.
+		// ViaTemptable also exercises the desc ORDER BY in the outer wrapper.
+		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
+		uniqueKeyColumns.SetColumnType("position", EnumColumnType)
+		rangeStartArgs := []interface{}{3, "a"}
+		rangeEndArgs := []interface{}{103, "z"}
+
+		query, _, err := BuildUniqueKeyRangeEndPreparedQueryViaTemptable(databaseName, originalTableName, uniqueKeyColumns, rangeStartArgs, rangeEndArgs, chunkSize, false, "test")
+		require.NoError(t, err)
+		expected := `
+			select /* gh-ost mydb.tbl test */ name, position
+			from (
+				select name, position
+				from
+					((select name, position from mydb.tbl where name = ? and position > ? order by name asc, concat(position) asc limit 500)
+					union all
+					(select name, position from mydb.tbl where name > ? and name < ? order by name asc, concat(position) asc limit 500)
+					union all
+					(select name, position from mydb.tbl where name = ? and position <= ? order by name asc, concat(position) asc limit 500)) t
+				order by name asc, concat(position) asc
+				limit 500
+			) select_osc_chunk
+			order by name desc, concat(position) desc
+			limit 1`
+		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
+	}
+}
+
+func TestSameFirstColumnValue(t *testing.T) {
+	{
+		// Identical integer values match.
+		require.True(t, sameFirstColumnValue([]interface{}{3, 17}, []interface{}{3, 117}))
+	}
+	{
+		// Different integer values do not match.
+		require.False(t, sameFirstColumnValue([]interface{}{3, 17}, []interface{}{4, 17}))
+	}
+	{
+		// Identical string values match.
+		require.True(t, sameFirstColumnValue([]interface{}{"abc", 1}, []interface{}{"abc", 2}))
+	}
+	{
+		// fmt.Sprintf("%v", x) is the comparison key — int(3) and "3" stringify
+		// identically and are therefore treated as equal. This is intentional:
+		// real callers pass type-consistent args originating from the same row.
+		require.True(t, sameFirstColumnValue([]interface{}{3, 1}, []interface{}{"3", 2}))
+	}
+}
+
+func TestNewTwoColumnRangeMeta(t *testing.T) {
+	{
+		// No enum columns → plain "col asc" / "col desc" ORDER BY clauses.
+		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
+		m := newTwoColumnRangeMeta(uniqueKeyColumns)
+		require.Equal(t, "`name`", m.col1Name)
+		require.Equal(t, "`position`", m.col2Name)
+		require.Equal(t, "?", m.col1Val)
+		require.Equal(t, "?", m.col2Val)
+		require.Equal(t, "`name` asc, `position` asc", m.orderByAsc)
+		require.Equal(t, "`name` desc, `position` desc", m.orderByDesc)
+	}
+	{
+		// Enum on first column only.
+		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
+		uniqueKeyColumns.SetColumnType("name", EnumColumnType)
+		m := newTwoColumnRangeMeta(uniqueKeyColumns)
+		require.Equal(t, "concat(`name`) asc, `position` asc", m.orderByAsc)
+		require.Equal(t, "concat(`name`) desc, `position` desc", m.orderByDesc)
+	}
+	{
+		// Enum on second column only.
+		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
+		uniqueKeyColumns.SetColumnType("position", EnumColumnType)
+		m := newTwoColumnRangeMeta(uniqueKeyColumns)
+		require.Equal(t, "`name` asc, concat(`position`) asc", m.orderByAsc)
+		require.Equal(t, "`name` desc, concat(`position`) desc", m.orderByDesc)
+	}
+	{
+		// Enum on both columns.
+		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
+		uniqueKeyColumns.SetColumnType("name", EnumColumnType)
+		uniqueKeyColumns.SetColumnType("position", EnumColumnType)
+		m := newTwoColumnRangeMeta(uniqueKeyColumns)
+		require.Equal(t, "concat(`name`) asc, concat(`position`) asc", m.orderByAsc)
+		require.Equal(t, "concat(`name`) desc, concat(`position`) desc", m.orderByDesc)
+	}
+}
+
+func TestBuildTwoColumnUnionParts(t *testing.T) {
+	rangeStartArgs := []interface{}{3, 17}
+	rangeEndArgs := []interface{}{103, 117}
+	part1, part2, part3, explodedArgs := buildTwoColumnUnionParts(
+		"name, position", "mydb.tbl",
+		"name", "position",
+		"?", "?", "?", "?",
+		">=", "order by name asc, position asc limit 500",
+		rangeStartArgs, rangeEndArgs,
+	)
+	require.Equal(t, normalizeQuery("(select name, position from mydb.tbl where name = ? and position >= ? order by name asc, position asc limit 500)"), normalizeQuery(part1))
+	require.Equal(t, normalizeQuery("(select name, position from mydb.tbl where name > ? and name < ? order by name asc, position asc limit 500)"), normalizeQuery(part2))
+	require.Equal(t, normalizeQuery("(select name, position from mydb.tbl where name = ? and position <= ? order by name asc, position asc limit 500)"), normalizeQuery(part3))
+	// Args follow the column order each subquery binds: (start1, start2), (start1, end1), (end1, end2).
+	require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
 }
 
 func TestBuildUniqueKeyMinValuesPreparedQuery(t *testing.T) {

--- a/go/sql/builder_test.go
+++ b/go/sql/builder_test.go
@@ -658,6 +658,50 @@ func TestBuildTwoColumnUnionParts(t *testing.T) {
 	require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
 }
 
+func TestBuildRangeInsertQueryTwoColumnGuards(t *testing.T) {
+	databaseName := "mydb"
+	originalTableName := "tbl"
+	ghostTableName := "ghost"
+	sharedColumnsListing := "id, name, position"
+	uniqueKey := "name_position_uidx"
+	uniqueKeyColumns := NewColumnList([]string{"name", "position"})
+	validValues := []string{"@v1", "@v2"}
+	validArgs := []interface{}{3, 17}
+
+	call := func(rangeStartValues, rangeEndValues []string, rangeStartArgs, rangeEndArgs []interface{}) error {
+		_, _, err := buildRangeInsertQueryTwoColumn(
+			databaseName, originalTableName, ghostTableName,
+			sharedColumnsListing, sharedColumnsListing,
+			uniqueKey, uniqueKeyColumns,
+			rangeStartValues, rangeEndValues,
+			rangeStartArgs, rangeEndArgs,
+			GreaterThanOrEqualsComparisonSign, "",
+		)
+		return err
+	}
+
+	{
+		// rangeStartValues length mismatch.
+		err := call([]string{"@v1"}, validValues, validArgs, validArgs)
+		require.ErrorContains(t, err, "got 2 columns but 1 rangeStartValues")
+	}
+	{
+		// rangeEndValues length mismatch.
+		err := call(validValues, []string{"@v1", "@v2", "@v3"}, validArgs, validArgs)
+		require.ErrorContains(t, err, "got 2 columns but 3 rangeEndValues")
+	}
+	{
+		// rangeStartArgs length mismatch.
+		err := call(validValues, validValues, []interface{}{3}, validArgs)
+		require.ErrorContains(t, err, "got 2 columns but 1 rangeStartArgs")
+	}
+	{
+		// rangeEndArgs length mismatch.
+		err := call(validValues, validValues, validArgs, []interface{}{})
+		require.ErrorContains(t, err, "got 2 columns but 0 rangeEndArgs")
+	}
+}
+
 func TestBuildUniqueKeyMinValuesPreparedQuery(t *testing.T) {
 	databaseName := "mydb"
 	originalTableName := "tbl"

--- a/go/sql/builder_test.go
+++ b/go/sql/builder_test.go
@@ -205,11 +205,11 @@ func TestBuildRangeInsertQuery(t *testing.T) {
 		expected := `
 			insert /* gh-ost mydb.tbl */ ignore
 			into mydb.ghost (id, name, position)
-			((select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1s and position >= @v2s for share nowait)
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1s and position >= @v2s for share nowait)
 			union all
 			(select id, name, position from mydb.tbl force index (name_position_uidx) where name > @v1s and name < @v1e for share nowait)
 			union all
-			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1e and position <= @v2e for share nowait))`
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1e and position <= @v2e for share nowait)`
 		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
 		require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
 	}
@@ -254,11 +254,11 @@ func TestBuildRangeInsertQuery(t *testing.T) {
 		expected := `
 			insert /* gh-ost mydb.tbl */ ignore
 			into mydb.ghost (id, name, position)
-			((select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1s and position > @v2s for share nowait)
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1s and position > @v2s for share nowait)
 			union all
 			(select id, name, position from mydb.tbl force index (name_position_uidx) where name > @v1s and name < @v1e for share nowait)
 			union all
-			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1e and position <= @v2e for share nowait))`
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1e and position <= @v2e for share nowait)`
 		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
 		require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
 	}
@@ -276,11 +276,11 @@ func TestBuildRangeInsertQuery(t *testing.T) {
 		expected := `
 			insert /* gh-ost mydb.tbl */ ignore
 			into mydb.ghost (id, name, position)
-			((select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1s and position >= @v2s )
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1s and position >= @v2s )
 			union all
 			(select id, name, position from mydb.tbl force index (name_position_uidx) where name > @v1s and name < @v1e )
 			union all
-			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1e and position <= @v2e ))`
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1e and position <= @v2e )`
 		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
 		require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
 	}
@@ -298,11 +298,11 @@ func TestBuildRangeInsertQuery(t *testing.T) {
 		expected := `
 			insert /* gh-ost mydb.tbl */ ignore
 			into mydb.ghost (id, name, position)
-			((select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1s and position >= @v2s lock in share mode)
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1s and position >= @v2s lock in share mode)
 			union all
 			(select id, name, position from mydb.tbl force index (name_position_uidx) where name > @v1s and name < @v1e lock in share mode)
 			union all
-			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1e and position <= @v2e lock in share mode))`
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1e and position <= @v2e lock in share mode)`
 		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
 		require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
 	}
@@ -356,11 +356,11 @@ func TestBuildRangeInsertQueryRenameMap(t *testing.T) {
 		expected := `
 			insert /* gh-ost mydb.tbl */ ignore
 			into mydb.ghost (id, name, location)
-			((select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1s and position >= @v2s for share nowait)
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1s and position >= @v2s for share nowait)
 			union all
 			(select id, name, position from mydb.tbl force index (name_position_uidx) where name > @v1s and name < @v1e for share nowait)
 			union all
-			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1e and position <= @v2e for share nowait))`
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1e and position <= @v2e for share nowait)`
 		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
 		require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
 	}
@@ -382,11 +382,11 @@ func TestBuildRangeInsertPreparedQuery(t *testing.T) {
 		expected := `
 			insert /* gh-ost mydb.tbl */ ignore
 			into mydb.ghost (id, name, position)
-			((select id, name, position from mydb.tbl force index (name_position_uidx) where name = ? and position >= ? for share nowait)
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = ? and position >= ? for share nowait)
 			union all
 			(select id, name, position from mydb.tbl force index (name_position_uidx) where name > ? and name < ? for share nowait)
 			union all
-			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = ? and position <= ? for share nowait))`
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = ? and position <= ? for share nowait)`
 		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
 		require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
 	}

--- a/go/sql/builder_test.go
+++ b/go/sql/builder_test.go
@@ -192,6 +192,7 @@ func TestBuildRangeInsertQuery(t *testing.T) {
 		require.Equal(t, []interface{}{3, 3, 103, 103}, explodedArgs)
 	}
 	{
+		// Different first-column values → 3-part UNION insert.
 		uniqueKey := "name_position_uidx"
 		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
 		rangeStartValues := []string{"@v1s", "@v2s"}
@@ -203,27 +204,14 @@ func TestBuildRangeInsertQuery(t *testing.T) {
 		require.NoError(t, err)
 		expected := `
 			insert /* gh-ost mydb.tbl */ ignore
-			into
-				mydb.ghost
-				(id, name, position)
-			(
-				select id, name, position
-				from
-					mydb.tbl
-				force index (name_position_uidx)
-				where
-					(((name > @v1s) or (((name = @v1s))
-					AND (position > @v2s))
-					or ((name = @v1s)
-					and (position = @v2s)))
-					and ((name < @v1e)
-					or (((name = @v1e))
-					AND (position < @v2e))
-					or ((name = @v1e) and (position = @v2e))))
-				for share nowait
-			)`
+			into mydb.ghost (id, name, position)
+			((select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1s and position >= @v2s for share nowait)
+			union all
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name > @v1s and name < @v1e for share nowait)
+			union all
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1e and position <= @v2e for share nowait))`
 		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
-		require.Equal(t, []interface{}{3, 3, 17, 3, 17, 103, 103, 117, 103, 117}, explodedArgs)
+		require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
 	}
 }
 
@@ -274,23 +262,14 @@ func TestBuildRangeInsertQueryRenameMap(t *testing.T) {
 		require.NoError(t, err)
 		expected := `
 			insert /* gh-ost mydb.tbl */ ignore
-			into
-				mydb.ghost
-				(id, name, location)
-			(
-				select id, name, position
-				from
-					mydb.tbl
-				force index (name_position_uidx)
-				where
-					(((name > @v1s) or (((name = @v1s))
-					AND (position > @v2s)) or ((name = @v1s) and (position = @v2s)))
-					and ((name < @v1e) or (((name = @v1e)) AND (position < @v2e))
-					or ((name = @v1e) and (position = @v2e))))
-				for share nowait
-			)`
+			into mydb.ghost (id, name, location)
+			((select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1s and position >= @v2s for share nowait)
+			union all
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name > @v1s and name < @v1e for share nowait)
+			union all
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = @v1e and position <= @v2e for share nowait))`
 		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
-		require.Equal(t, []interface{}{3, 3, 17, 3, 17, 103, 103, 117, 103, 117}, explodedArgs)
+		require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
 	}
 }
 
@@ -309,19 +288,14 @@ func TestBuildRangeInsertPreparedQuery(t *testing.T) {
 		require.NoError(t, err)
 		expected := `
 			insert /* gh-ost mydb.tbl */ ignore
-			into
-				mydb.ghost
-				(id, name, position)
-			(
-				select id, name, position
-				from
-					mydb.tbl
-				force index (name_position_uidx)
-				where (((name > ?) or (((name = ?)) AND (position > ?)) or ((name = ?) and (position = ?))) and ((name < ?) or (((name = ?)) AND (position < ?)) or ((name = ?) and (position = ?))))
-				for share nowait
-			)`
+			into mydb.ghost (id, name, position)
+			((select id, name, position from mydb.tbl force index (name_position_uidx) where name = ? and position >= ? for share nowait)
+			union all
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name > ? and name < ? for share nowait)
+			union all
+			(select id, name, position from mydb.tbl force index (name_position_uidx) where name = ? and position <= ? for share nowait))`
 		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
-		require.Equal(t, []interface{}{3, 3, 17, 3, 17, 103, 103, 117, 103, 117}, explodedArgs)
+		require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
 	}
 }
 
@@ -330,6 +304,7 @@ func TestBuildUniqueKeyRangeEndPreparedQueryViaOffset(t *testing.T) {
 	originalTableName := "tbl"
 	var chunkSize int64 = 500
 	{
+		// Different first-column values → 3-part UNION for efficient boundary seeks.
 		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
 		rangeStartArgs := []interface{}{3, 17}
 		rangeEndArgs := []interface{}{103, 117}
@@ -340,15 +315,39 @@ func TestBuildUniqueKeyRangeEndPreparedQueryViaOffset(t *testing.T) {
 			select /* gh-ost mydb.tbl test */
 				name, position
 			from
-				mydb.tbl
-			where
-				((name > ?) or (((name = ?)) AND (position > ?))) and ((name < ?) or (((name = ?)) AND (position < ?)) or ((name = ?) and (position = ?)))
+				((select name, position from mydb.tbl where name = ? and position > ? order by name asc, position asc limit 500)
+				union all
+				(select name, position from mydb.tbl where name > ? and name < ? order by name asc, position asc limit 500)
+				union all
+				(select name, position from mydb.tbl where name = ? and position <= ? order by name asc, position asc limit 500)) t
 			order by
 				name asc, position asc
 			limit 1
 			offset 499`
 		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
-		require.Equal(t, []interface{}{3, 3, 17, 103, 103, 117, 103, 117}, explodedArgs)
+		require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
+	}
+	{
+		// Same first-column value → single range query (no UNION needed).
+		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
+		rangeStartArgs := []interface{}{3, 17}
+		rangeEndArgs := []interface{}{3, 117}
+
+		query, explodedArgs, err := BuildUniqueKeyRangeEndPreparedQueryViaOffset(databaseName, originalTableName, uniqueKeyColumns, rangeStartArgs, rangeEndArgs, chunkSize, false, "test")
+		require.NoError(t, err)
+		expected := `
+			select /* gh-ost mydb.tbl test */
+				name, position
+			from
+				mydb.tbl
+			where
+				(name = ? and position > ? and position <= ?)
+			order by
+				name asc, position asc
+			limit 1
+			offset 499`
+		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
+		require.Equal(t, []interface{}{3, 17, 117}, explodedArgs)
 	}
 }
 
@@ -357,6 +356,7 @@ func TestBuildUniqueKeyRangeEndPreparedQueryViaTemptable(t *testing.T) {
 	originalTableName := "tbl"
 	var chunkSize int64 = 500
 	{
+		// Different first-column values → 3-part UNION for efficient boundary seeks.
 		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
 		rangeStartArgs := []interface{}{3, 17}
 		rangeEndArgs := []interface{}{103, 117}
@@ -364,23 +364,44 @@ func TestBuildUniqueKeyRangeEndPreparedQueryViaTemptable(t *testing.T) {
 		query, explodedArgs, err := BuildUniqueKeyRangeEndPreparedQueryViaTemptable(databaseName, originalTableName, uniqueKeyColumns, rangeStartArgs, rangeEndArgs, chunkSize, false, "test")
 		require.NoError(t, err)
 		expected := `
-			select /* gh-ost mydb.tbl test */
-				name, position
+			select /* gh-ost mydb.tbl test */ name, position
 			from (
-				select
-					name, position
+				select name, position
 				from
-					mydb.tbl
-				where ((name > ?) or (((name = ?)) AND (position > ?))) and ((name < ?) or (((name = ?)) AND (position < ?)) or ((name = ?) and (position = ?)))
-				order by
-					name asc, position asc
+					((select name, position from mydb.tbl where name = ? and position > ? order by name asc, position asc limit 500)
+					union all
+					(select name, position from mydb.tbl where name > ? and name < ? order by name asc, position asc limit 500)
+					union all
+					(select name, position from mydb.tbl where name = ? and position <= ? order by name asc, position asc limit 500)) t
+				order by name asc, position asc
 				limit 500
 			) select_osc_chunk
-			order by
-				name desc, position desc
+			order by name desc, position desc
 			limit 1`
 		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
-		require.Equal(t, []interface{}{3, 3, 17, 103, 103, 117, 103, 117}, explodedArgs)
+		require.Equal(t, []interface{}{3, 17, 3, 103, 103, 117}, explodedArgs)
+	}
+	{
+		// Same first-column value → single range query (no UNION needed).
+		uniqueKeyColumns := NewColumnList([]string{"name", "position"})
+		rangeStartArgs := []interface{}{3, 17}
+		rangeEndArgs := []interface{}{3, 117}
+
+		query, explodedArgs, err := BuildUniqueKeyRangeEndPreparedQueryViaTemptable(databaseName, originalTableName, uniqueKeyColumns, rangeStartArgs, rangeEndArgs, chunkSize, false, "test")
+		require.NoError(t, err)
+		expected := `
+			select /* gh-ost mydb.tbl test */ name, position
+			from (
+				select name, position
+				from mydb.tbl
+				where (name = ? and position > ? and position <= ?)
+				order by name asc, position asc
+				limit 500
+			) select_osc_chunk
+			order by name desc, position desc
+			limit 1`
+		require.Equal(t, normalizeQuery(expected), normalizeQuery(query))
+		require.Equal(t, []interface{}{3, 17, 117}, explodedArgs)
 	}
 }
 


### PR DESCRIPTION
## A Pull Request should be associated with an Issue.

Related issue: https://github.com/github/gh-ost/issues/1669

### Description

This PR introduces an optimized query pattern for tables with composite primary keys. As described in the linked issue, gh-ost's queries against these tables can currently be very slow. We've seen a single query take up to 16 minutes, resulting in slow migrations that might not even finish when gh-ost falls behind in binlog streaming. The new query pattern has a constant query time (~30ms in our testing) regardless of the table's data shape. We're only introducing it for two-column composite keys because the complexity would grow exponentially with more columns.

We're introducing the new query pattern in `BuildRangeInsertQuery`, `BuildUniqueKeyRangeEndPreparedQueryViaOffset`, `BuildUniqueKeyRangeEndPreparedQueryViaTemptable`.

> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
