### PR TITLE
Emit row-copy progress gauges via StatsD

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -238,7 +238,7 @@ type MigrationContext struct {
 	AbortError error
 	abortMutex *sync.Mutex
 
-	Metrics *metrics.Client
+	Metrics metrics.MemStatsGaugeEmitter
 
 	OriginalTableColumnsOnApplier    *sql.ColumnList
 	OriginalTableColumns             *sql.ColumnList

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/github/gh-ost/go/base"
 	"github.com/github/gh-ost/go/binlog"
+	"github.com/github/gh-ost/go/metrics"
 	"github.com/github/gh-ost/go/mysql"
 	"github.com/github/gh-ost/go/sql"
 )
@@ -1167,9 +1168,20 @@ func (mgtr *Migrator) initiateInspector() (err error) {
 	return nil
 }
 
-// reportStatus samples progress and optionally prints status output.
+// emitProgressMetrics emits StatsD gauges from a progress snapshot.
+func (mgtr *Migrator) emitProgressMetrics(snap migrationProgressSnapshot) {
+	metrics.EmitProgressGauges(
+		mgtr.migrationContext.Metrics,
+		snap.totalRowsCopied,
+		snap.rowsEstimate,
+		snap.dmlApplied,
+	)
+}
+
+// reportStatus samples progress, emits metrics, and optionally prints status output.
 func (mgtr *Migrator) reportStatus(rule PrintStatusRule, writers ...io.Writer) {
 	snap := mgtr.sampleMigrationProgress()
+	mgtr.emitProgressMetrics(snap)
 	mgtr.printStatus(rule, snap, writers...)
 }
 

--- a/go/logic/migrator_test.go
+++ b/go/logic/migrator_test.go
@@ -407,6 +407,78 @@ func TestMigratorGetMigrationStateAndETA(t *testing.T) {
 	}
 }
 
+type progressGaugeSpy struct {
+	names  []string
+	values []float64
+}
+
+func (s *progressGaugeSpy) Gauge(name string, value float64, _ ...string) {
+	s.names = append(s.names, name)
+	s.values = append(s.values, value)
+}
+
+func TestReportStatusEmitsProgressGaugesEveryTick(t *testing.T) {
+	spy := &progressGaugeSpy{}
+	ctx := base.NewMigrationContext()
+	ctx.Metrics = spy
+	atomic.StoreInt64(&ctx.TotalRowsCopied, 1000)
+	atomic.StoreInt64(&ctx.RowsEstimate, 5000)
+	atomic.StoreInt64(&ctx.TotalDMLEventsApplied, 42)
+
+	migrator := NewMigrator(ctx, "test")
+	migrator.reportStatus(NoPrintStatusRule, io.Discard)
+	require.Len(t, spy.names, 3)
+	assert.Equal(t, []string{
+		"row_copy.rows_copied",
+		"row_copy.rows_estimate",
+		"dml.events_applied",
+	}, spy.names)
+	assert.Equal(t, []float64{1000, 5000, 42}, spy.values)
+	assert.InDelta(t, 20.0, ctx.GetProgressPct(), 0.01)
+
+	spy.names = nil
+	spy.values = nil
+	atomic.StoreInt64(&ctx.TotalDMLEventsApplied, 100)
+	migrator.reportStatus(NoPrintStatusRule, io.Discard)
+	require.Len(t, spy.names, 3)
+	assert.Equal(t, []float64{1000, 5000, 100}, spy.values)
+}
+
+func TestReportStatusEmitsGaugesWhenRowCopyComplete(t *testing.T) {
+	spy := &progressGaugeSpy{}
+	ctx := base.NewMigrationContext()
+	ctx.Metrics = spy
+	atomic.StoreInt64(&ctx.TotalRowsCopied, 5000)
+	atomic.StoreInt64(&ctx.RowsEstimate, 10000)
+
+	migrator := NewMigrator(ctx, "test")
+	atomic.StoreInt64(&migrator.rowCopyCompleteFlag, 1)
+	migrator.reportStatus(NoPrintStatusRule, io.Discard)
+
+	require.Len(t, spy.names, 3)
+	assert.Equal(t, float64(5000), spy.values[0])
+	assert.Equal(t, float64(5000), spy.values[1], "rows_estimate tracks rows_copied when row copy is complete")
+}
+
+func TestReportStatusEmitsGaugesWhenPrintSuppressed(t *testing.T) {
+	spy := &progressGaugeSpy{}
+	ctx := base.NewMigrationContext()
+	ctx.Metrics = spy
+	ctx.StartTime = time.Now().Add(-99 * time.Second)
+	atomic.StoreInt64(&ctx.TotalRowsCopied, 1000)
+	atomic.StoreInt64(&ctx.RowsEstimate, 5000)
+	atomic.StoreInt64(&ctx.EtaRowsPerSecond, 1)
+
+	migrator := NewMigrator(ctx, "test")
+	snap := migrator.migrationProgressSnapshot()
+	_, _, etaDuration := migrator.getMigrationStateAndETA(snap.rowsEstimate)
+	require.False(t, migrator.shouldPrintStatus(HeuristicPrintStatusRule, snap.elapsedSeconds, etaDuration))
+
+	migrator.reportStatus(HeuristicPrintStatusRule, io.Discard)
+	require.Len(t, spy.names, 3)
+	assert.Equal(t, []float64{1000, 5000, 0}, spy.values)
+}
+
 func TestMigratorShouldPrintStatus(t *testing.T) {
 	migrationContext := base.NewMigrationContext()
 	migrator := NewMigrator(migrationContext, "1.2.3")

--- a/go/metrics/progress.go
+++ b/go/metrics/progress.go
@@ -1,0 +1,17 @@
+/*
+   Copyright 2022 GitHub Inc.
+	 See https://github.com/github/gh-ost/blob/master/LICENSE
+*/
+
+package metrics
+
+// EmitProgressGauges emits row-copy and DML progress gauges (namespace is applied by the client):
+// gh_ost.row_copy.rows_copied, gh_ost.row_copy.rows_estimate, gh_ost.dml.events_applied.
+func EmitProgressGauges(emit MemStatsGaugeEmitter, rowsCopied, rowsEstimate, dmlEventsApplied int64) {
+	if emit == nil {
+		return
+	}
+	emit.Gauge("row_copy.rows_copied", float64(rowsCopied))
+	emit.Gauge("row_copy.rows_estimate", float64(rowsEstimate))
+	emit.Gauge("dml.events_applied", float64(dmlEventsApplied))
+}

--- a/go/metrics/progress_test.go
+++ b/go/metrics/progress_test.go
@@ -1,0 +1,33 @@
+/*
+   Copyright 2022 GitHub Inc.
+	 See https://github.com/github/gh-ost/blob/master/LICENSE
+*/
+
+package metrics
+
+import "testing"
+
+func TestEmitProgressGauges(t *testing.T) {
+	spy := &gaugeSpy{}
+	EmitProgressGauges(spy, 1000, 5000, 42)
+
+	wantNames := []string{
+		"row_copy.rows_copied",
+		"row_copy.rows_estimate",
+		"dml.events_applied",
+	}
+	wantVals := []float64{1000, 5000, 42}
+
+	if len(spy.names) != len(wantNames) {
+		t.Fatalf("got %d gauges, want %d", len(spy.names), len(wantNames))
+	}
+	for i := range wantNames {
+		if spy.names[i] != wantNames[i] || spy.values[i] != wantVals[i] {
+			t.Fatalf("[%d] got %s=%v want %s=%v", i, spy.names[i], spy.values[i], wantNames[i], wantVals[i])
+		}
+	}
+}
+
+func TestEmitProgressGauges_nilSafe(t *testing.T) {
+	EmitProgressGauges(nil, 1, 2, 3)
+}


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/1672
Closes: https://github.com/Shopify/schema-migrations/issues/5453

### Description

Add gh_ost.row_copy.rows_copied, gh_ost.row_copy.rows_estimate, and gh_ost.dml.events_applied gauges on each reportStatus tick, sampled from migrationProgressSnapshot.

## 🎩 
Running the gh-ost binary with statsd flags adding a column to fake_data results in:
<img width="1390" height="344" alt="Screenshot 2026-05-27 at 12 43 40 AM" src="https://github.com/user-attachments/assets/f65a4249-2509-4bbb-860d-82a5678be236" />


> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
