### PR TITLE
Emit replication and heartbeat lag

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -238,7 +238,7 @@ type MigrationContext struct {
 	AbortError error
 	abortMutex *sync.Mutex
 
-	Metrics metrics.MemStatsGaugeEmitter
+	Metrics metrics.Emitter
 
 	OriginalTableColumnsOnApplier    *sql.ColumnList
 	OriginalTableColumns             *sql.ColumnList

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -238,7 +238,7 @@ type MigrationContext struct {
 	AbortError error
 	abortMutex *sync.Mutex
 
-	Metrics metrics.Emitter
+	Metrics metrics.MemStatsGaugeEmitter
 
 	OriginalTableColumnsOnApplier    *sql.ColumnList
 	OriginalTableColumns             *sql.ColumnList

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -1182,7 +1182,7 @@ func (mgtr *Migrator) emitProgressMetrics(snap migrationProgressSnapshot) {
 		snap.applyEventsCapacity,
 	)
 	isThrottled, _, _ := mgtr.migrationContext.IsThrottled()
-	metrics.EmitLagHistograms(
+	metrics.EmitLagGauges(
 		mgtr.migrationContext.Metrics,
 		snap.replicationLagSeconds,
 		snap.heartbeatLagSeconds,

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -1168,7 +1168,7 @@ func (mgtr *Migrator) initiateInspector() (err error) {
 	return nil
 }
 
-// emitProgressMetrics emits StatsD gauges from a progress snapshot.
+// emitProgressMetrics emits StatsD gauges
 func (mgtr *Migrator) emitProgressMetrics(snap migrationProgressSnapshot) {
 	metrics.EmitProgressGauges(
 		mgtr.migrationContext.Metrics,
@@ -1180,6 +1180,13 @@ func (mgtr *Migrator) emitProgressMetrics(snap migrationProgressSnapshot) {
 		mgtr.migrationContext.Metrics,
 		snap.applyEventsBacklog,
 		snap.applyEventsCapacity,
+	)
+	isThrottled, _, _ := mgtr.migrationContext.IsThrottled()
+	metrics.EmitLagHistograms(
+		mgtr.migrationContext.Metrics,
+		snap.replicationLagSeconds,
+		snap.heartbeatLagSeconds,
+		isThrottled,
 	)
 }
 

--- a/go/logic/migrator_test.go
+++ b/go/logic/migrator_test.go
@@ -410,26 +410,13 @@ func TestMigratorGetMigrationStateAndETA(t *testing.T) {
 type progressGaugeSpy struct {
 	names  []string
 	values []float64
+	tags   [][]string
 }
 
-func (s *progressGaugeSpy) Gauge(name string, value float64, _ ...string) {
+func (s *progressGaugeSpy) Gauge(name string, value float64, tags ...string) {
 	s.names = append(s.names, name)
 	s.values = append(s.values, value)
-}
-
-func (s *progressGaugeSpy) Histogram(string, float64, ...string) {}
-
-type statusMetricsSpy struct {
-	progressGaugeSpy
-	histogramNames  []string
-	histogramValues []float64
-	histogramTags   [][]string
-}
-
-func (s *statusMetricsSpy) Histogram(name string, value float64, tags ...string) {
-	s.histogramNames = append(s.histogramNames, name)
-	s.histogramValues = append(s.histogramValues, value)
-	s.histogramTags = append(s.histogramTags, append([]string(nil), tags...))
+	s.tags = append(s.tags, append([]string(nil), tags...))
 }
 
 func TestReportStatusEmitsProgressGaugesEveryTick(t *testing.T) {
@@ -442,7 +429,7 @@ func TestReportStatusEmitsProgressGaugesEveryTick(t *testing.T) {
 
 	migrator := NewMigrator(ctx, "test")
 	migrator.reportStatus(NoPrintStatusRule, io.Discard)
-	require.Len(t, spy.names, 6)
+	require.Len(t, spy.names, 8)
 	assert.Equal(t, []string{
 		"row_copy.rows_copied",
 		"row_copy.rows_estimate",
@@ -450,16 +437,18 @@ func TestReportStatusEmitsProgressGaugesEveryTick(t *testing.T) {
 		"binlog.backlog_size",
 		"binlog.backlog_capacity",
 		"binlog.backlog_utilization",
+		"lag.replication_seconds",
+		"lag.heartbeat_seconds",
 	}, spy.names)
-	assert.Equal(t, []float64{1000, 5000, 42, 0, float64(cap(migrator.applyEventsQueue)), 0}, spy.values)
+	assert.Equal(t, []float64{1000, 5000, 42, 0, float64(cap(migrator.applyEventsQueue)), 0}, spy.values[:6])
 	assert.InDelta(t, 20.0, ctx.GetProgressPct(), 0.01)
 
 	spy.names = nil
 	spy.values = nil
 	atomic.StoreInt64(&ctx.TotalDMLEventsApplied, 100)
 	migrator.reportStatus(NoPrintStatusRule, io.Discard)
-	require.Len(t, spy.names, 6)
-	assert.Equal(t, []float64{1000, 5000, 100, 0, float64(cap(migrator.applyEventsQueue)), 0}, spy.values)
+	require.Len(t, spy.names, 8)
+	assert.Equal(t, []float64{1000, 5000, 100, 0, float64(cap(migrator.applyEventsQueue)), 0}, spy.values[:6])
 }
 
 func TestReportStatusEmitsBinlogBacklogGauges(t *testing.T) {
@@ -478,7 +467,7 @@ func TestReportStatusEmitsBinlogBacklogGauges(t *testing.T) {
 	migrator.reportStatus(NoPrintStatusRule, io.Discard)
 
 	capacity := float64(cap(migrator.applyEventsQueue))
-	require.Len(t, spy.names, 6)
+	require.Len(t, spy.names, 8)
 	assert.Equal(t, float64(2), spy.values[3])
 	assert.Equal(t, capacity, spy.values[4])
 	assert.InDelta(t, 2/capacity, spy.values[5], 1e-9)
@@ -495,7 +484,7 @@ func TestReportStatusEmitsGaugesWhenRowCopyComplete(t *testing.T) {
 	atomic.StoreInt64(&migrator.rowCopyCompleteFlag, 1)
 	migrator.reportStatus(NoPrintStatusRule, io.Discard)
 
-	require.Len(t, spy.names, 6)
+	require.Len(t, spy.names, 8)
 	assert.Equal(t, float64(5000), spy.values[0])
 	assert.Equal(t, float64(5000), spy.values[1], "rows_estimate tracks rows_copied when row copy is complete")
 }
@@ -515,31 +504,12 @@ func TestReportStatusEmitsGaugesWhenPrintSuppressed(t *testing.T) {
 	require.False(t, migrator.shouldPrintStatus(HeuristicPrintStatusRule, snap.elapsedSeconds, etaDuration))
 
 	migrator.reportStatus(HeuristicPrintStatusRule, io.Discard)
-	require.Len(t, spy.names, 6)
-	assert.Equal(t, []float64{1000, 5000, 0, 0, float64(cap(migrator.applyEventsQueue)), 0}, spy.values)
+	require.Len(t, spy.names, 8)
+	assert.Equal(t, []float64{1000, 5000, 0, 0, float64(cap(migrator.applyEventsQueue)), 0}, spy.values[:6])
 }
 
-func TestReportStatusEmitsLagHistogramsWhenNotThrottled(t *testing.T) {
-	spy := &statusMetricsSpy{}
-	ctx := base.NewMigrationContext()
-	ctx.Metrics = spy
-	atomic.StoreInt64(&ctx.CurrentLag, int64(3*time.Second))
-	ctx.SetLastHeartbeatOnChangelogTime(time.Now().Add(-2 * time.Second))
-
-	migrator := NewMigrator(ctx, "test")
-	migrator.reportStatus(NoPrintStatusRule, io.Discard)
-
-	require.Len(t, spy.histogramNames, 2)
-	assert.Equal(t, []string{"lag.replication_seconds", "lag.heartbeat_seconds"}, spy.histogramNames)
-	assert.InDelta(t, 3.0, spy.histogramValues[0], 0.01)
-	assert.InDelta(t, 2.0, spy.histogramValues[1], 0.5)
-	require.Len(t, spy.histogramTags[0], 1)
-	assert.Equal(t, "throttled:false", spy.histogramTags[0][0])
-	assert.Equal(t, "throttled:false", spy.histogramTags[1][0])
-}
-
-func TestReportStatusEmitsLagHistogramsWhenThrottled(t *testing.T) {
-	spy := &statusMetricsSpy{}
+func TestReportStatusEmitsLagGaugesWhenThrottled(t *testing.T) {
+	spy := &progressGaugeSpy{}
 	ctx := base.NewMigrationContext()
 	ctx.Metrics = spy
 	ctx.SetThrottled(true, "max-lag-millis", base.NoThrottleReasonHint)
@@ -549,9 +519,12 @@ func TestReportStatusEmitsLagHistogramsWhenThrottled(t *testing.T) {
 	migrator := NewMigrator(ctx, "test")
 	migrator.reportStatus(NoPrintStatusRule, io.Discard)
 
-	require.Len(t, spy.histogramNames, 2)
-	assert.Equal(t, "throttled:true", spy.histogramTags[0][0])
-	assert.Equal(t, "throttled:true", spy.histogramTags[1][0])
+	require.GreaterOrEqual(t, len(spy.names), 8)
+	assert.Equal(t, "lag.replication_seconds", spy.names[6])
+	assert.Equal(t, "lag.heartbeat_seconds", spy.names[7])
+	require.Len(t, spy.tags[6], 1)
+	assert.Equal(t, "throttled:true", spy.tags[6][0])
+	assert.Equal(t, "throttled:true", spy.tags[7][0])
 }
 
 func TestMigratorShouldPrintStatus(t *testing.T) {

--- a/go/logic/migrator_test.go
+++ b/go/logic/migrator_test.go
@@ -417,6 +417,21 @@ func (s *progressGaugeSpy) Gauge(name string, value float64, _ ...string) {
 	s.values = append(s.values, value)
 }
 
+func (s *progressGaugeSpy) Histogram(string, float64, ...string) {}
+
+type statusMetricsSpy struct {
+	progressGaugeSpy
+	histogramNames  []string
+	histogramValues []float64
+	histogramTags   [][]string
+}
+
+func (s *statusMetricsSpy) Histogram(name string, value float64, tags ...string) {
+	s.histogramNames = append(s.histogramNames, name)
+	s.histogramValues = append(s.histogramValues, value)
+	s.histogramTags = append(s.histogramTags, append([]string(nil), tags...))
+}
+
 func TestReportStatusEmitsProgressGaugesEveryTick(t *testing.T) {
 	spy := &progressGaugeSpy{}
 	ctx := base.NewMigrationContext()
@@ -502,6 +517,41 @@ func TestReportStatusEmitsGaugesWhenPrintSuppressed(t *testing.T) {
 	migrator.reportStatus(HeuristicPrintStatusRule, io.Discard)
 	require.Len(t, spy.names, 6)
 	assert.Equal(t, []float64{1000, 5000, 0, 0, float64(cap(migrator.applyEventsQueue)), 0}, spy.values)
+}
+
+func TestReportStatusEmitsLagHistogramsWhenNotThrottled(t *testing.T) {
+	spy := &statusMetricsSpy{}
+	ctx := base.NewMigrationContext()
+	ctx.Metrics = spy
+	atomic.StoreInt64(&ctx.CurrentLag, int64(3*time.Second))
+	ctx.SetLastHeartbeatOnChangelogTime(time.Now().Add(-2 * time.Second))
+
+	migrator := NewMigrator(ctx, "test")
+	migrator.reportStatus(NoPrintStatusRule, io.Discard)
+
+	require.Len(t, spy.histogramNames, 2)
+	assert.Equal(t, []string{"lag.replication_seconds", "lag.heartbeat_seconds"}, spy.histogramNames)
+	assert.InDelta(t, 3.0, spy.histogramValues[0], 0.01)
+	assert.InDelta(t, 2.0, spy.histogramValues[1], 0.5)
+	require.Len(t, spy.histogramTags[0], 1)
+	assert.Equal(t, "throttled:false", spy.histogramTags[0][0])
+	assert.Equal(t, "throttled:false", spy.histogramTags[1][0])
+}
+
+func TestReportStatusEmitsLagHistogramsWhenThrottled(t *testing.T) {
+	spy := &statusMetricsSpy{}
+	ctx := base.NewMigrationContext()
+	ctx.Metrics = spy
+	ctx.SetThrottled(true, "max-lag-millis", base.NoThrottleReasonHint)
+	atomic.StoreInt64(&ctx.CurrentLag, int64(5*time.Second))
+	ctx.SetLastHeartbeatOnChangelogTime(time.Now().Add(-4 * time.Second))
+
+	migrator := NewMigrator(ctx, "test")
+	migrator.reportStatus(NoPrintStatusRule, io.Discard)
+
+	require.Len(t, spy.histogramNames, 2)
+	assert.Equal(t, "throttled:true", spy.histogramTags[0][0])
+	assert.Equal(t, "throttled:true", spy.histogramTags[1][0])
 }
 
 func TestMigratorShouldPrintStatus(t *testing.T) {

--- a/go/metrics/client.go
+++ b/go/metrics/client.go
@@ -21,16 +21,9 @@ type Client struct {
 	sd *statsd.Client
 }
 
+// MemStatsGaugeEmitter is implemented by *Client; used for tests without UDP.
 type MemStatsGaugeEmitter interface {
 	Gauge(name string, value float64, tags ...string)
-}
-type HistogramEmitter interface {
-	Histogram(name string, value float64, tags ...string)
-}
-
-type Emitter interface {
-	MemStatsGaugeEmitter
-	HistogramEmitter
 }
 
 // NewClient connects to addr for StatsD. If addr is empty, returns Noop and nil error.
@@ -70,13 +63,6 @@ func (c *Client) Count(name string, value int64, tags ...string) {
 		return
 	}
 	_ = c.sd.Count(name, value, tags, 1.0)
-}
-
-func (c *Client) Histogram(name string, value float64, tags ...string) {
-	if c.sd == nil {
-		return
-	}
-	_ = c.sd.Histogram(name, value, tags, 1.0)
 }
 
 // Close flushes buffered metrics; safe for Noop.

--- a/go/metrics/client.go
+++ b/go/metrics/client.go
@@ -21,6 +21,22 @@ type Client struct {
 	sd *statsd.Client
 }
 
+// MemStatsGaugeEmitter is implemented by *Client; used for tests without UDP.
+type MemStatsGaugeEmitter interface {
+	Gauge(name string, value float64, tags ...string)
+}
+
+// HistogramEmitter is implemented by *Client; used for tests without UDP.
+type HistogramEmitter interface {
+	Histogram(name string, value float64, tags ...string)
+}
+
+// Emitter combines gauge and histogram emission for migration status metrics.
+type Emitter interface {
+	MemStatsGaugeEmitter
+	HistogramEmitter
+}
+
 // NewClient connects to addr for StatsD. If addr is empty, returns Noop and nil error.
 // namespace is typically "gh_ost." (metrics are named namespace + short name, e.g. gh_ost.startup).
 // tags are global tags applied to every metric (repeatable --statsd-tags).
@@ -58,6 +74,13 @@ func (c *Client) Count(name string, value int64, tags ...string) {
 		return
 	}
 	_ = c.sd.Count(name, value, tags, 1.0)
+}
+
+func (c *Client) Histogram(name string, value float64, tags ...string) {
+	if c.sd == nil {
+		return
+	}
+	_ = c.sd.Histogram(name, value, tags, 1.0)
 }
 
 // Close flushes buffered metrics; safe for Noop.

--- a/go/metrics/client.go
+++ b/go/metrics/client.go
@@ -21,17 +21,13 @@ type Client struct {
 	sd *statsd.Client
 }
 
-// MemStatsGaugeEmitter is implemented by *Client; used for tests without UDP.
 type MemStatsGaugeEmitter interface {
 	Gauge(name string, value float64, tags ...string)
 }
-
-// HistogramEmitter is implemented by *Client; used for tests without UDP.
 type HistogramEmitter interface {
 	Histogram(name string, value float64, tags ...string)
 }
 
-// Emitter combines gauge and histogram emission for migration status metrics.
 type Emitter interface {
 	MemStatsGaugeEmitter
 	HistogramEmitter

--- a/go/metrics/go_runtime.go
+++ b/go/metrics/go_runtime.go
@@ -11,11 +11,6 @@ import (
 	"time"
 )
 
-// MemStatsGaugeEmitter is implemented by *Client; used for tests without UDP.
-type MemStatsGaugeEmitter interface {
-	Gauge(name string, value float64, tags ...string)
-}
-
 // EmitGoRuntimeGauges emits gh_ost.go_runtime.* gauges (namespace is applied by the client).
 // m and numGoroutine are typically from runtime.ReadMemStats and runtime.NumGoroutine.
 func EmitGoRuntimeGauges(emit MemStatsGaugeEmitter, m *runtime.MemStats, numGoroutine int) {

--- a/go/metrics/go_runtime_test.go
+++ b/go/metrics/go_runtime_test.go
@@ -15,11 +15,13 @@ import (
 type gaugeSpy struct {
 	names  []string
 	values []float64
+	tags   [][]string
 }
 
-func (g *gaugeSpy) Gauge(name string, value float64, _ ...string) {
+func (g *gaugeSpy) Gauge(name string, value float64, tags ...string) {
 	g.names = append(g.names, name)
 	g.values = append(g.values, value)
+	g.tags = append(g.tags, append([]string(nil), tags...))
 }
 
 func TestEmitGoRuntimeGauges(t *testing.T) {

--- a/go/metrics/lag.go
+++ b/go/metrics/lag.go
@@ -1,0 +1,19 @@
+/*
+   Copyright 2022 GitHub Inc.
+	 See https://github.com/github/gh-ost/blob/master/LICENSE
+*/
+
+package metrics
+
+import "fmt"
+
+// EmitLagHistograms emits replication and heartbeat lag histograms (namespace is applied by the client):
+// gh_ost.lag.replication_seconds, gh_ost.lag.heartbeat_seconds, each tagged throttled:true|false.
+func EmitLagHistograms(emit HistogramEmitter, replicationLagSeconds, heartbeatLagSeconds float64, throttled bool) {
+	if emit == nil {
+		return
+	}
+	tags := []string{fmt.Sprintf("throttled:%t", throttled)}
+	emit.Histogram("lag.replication_seconds", replicationLagSeconds, tags...)
+	emit.Histogram("lag.heartbeat_seconds", heartbeatLagSeconds, tags...)
+}

--- a/go/metrics/lag.go
+++ b/go/metrics/lag.go
@@ -7,13 +7,17 @@ package metrics
 
 import "fmt"
 
-// EmitLagHistograms emits replication and heartbeat lag histograms (namespace is applied by the client):
+// EmitLagGauges emits replication and heartbeat lag gauges (namespace is applied by the client):
 // gh_ost.lag.replication_seconds, gh_ost.lag.heartbeat_seconds, each tagged throttled:true|false.
-func EmitLagHistograms(emit HistogramEmitter, replicationLagSeconds, heartbeatLagSeconds float64, throttled bool) {
+//
+// These are point-in-time readings each status tick (not a distribution), so gauges are used
+// rather than histograms — DogStatsD histogram aggregation exposes count/max series that do not
+// match the log line lag values in Prometheus/Grafana.
+func EmitLagGauges(emit MemStatsGaugeEmitter, replicationLagSeconds, heartbeatLagSeconds float64, throttled bool) {
 	if emit == nil {
 		return
 	}
 	tags := []string{fmt.Sprintf("throttled:%t", throttled)}
-	emit.Histogram("lag.replication_seconds", replicationLagSeconds, tags...)
-	emit.Histogram("lag.heartbeat_seconds", heartbeatLagSeconds, tags...)
+	emit.Gauge("lag.replication_seconds", replicationLagSeconds, tags...)
+	emit.Gauge("lag.heartbeat_seconds", heartbeatLagSeconds, tags...)
 }

--- a/go/metrics/lag_test.go
+++ b/go/metrics/lag_test.go
@@ -7,28 +7,16 @@ package metrics
 
 import "testing"
 
-type histogramSpy struct {
-	names  []string
-	values []float64
-	tags   [][]string
-}
-
-func (s *histogramSpy) Histogram(name string, value float64, tags ...string) {
-	s.names = append(s.names, name)
-	s.values = append(s.values, value)
-	s.tags = append(s.tags, append([]string(nil), tags...))
-}
-
-func TestEmitLagHistograms_notThrottled(t *testing.T) {
-	spy := &histogramSpy{}
-	EmitLagHistograms(spy, 2.5, 1.25, false)
+func TestEmitLagGauges_notThrottled(t *testing.T) {
+	spy := &gaugeSpy{}
+	EmitLagGauges(spy, 2.5, 1.25, false)
 
 	wantNames := []string{"lag.replication_seconds", "lag.heartbeat_seconds"}
 	wantVals := []float64{2.5, 1.25}
 	wantTags := []string{"throttled:false"}
 
-	if len(spy.names) != 2 {
-		t.Fatalf("got %d histograms, want 2", len(spy.names))
+	if len(spy.names) != len(wantNames) {
+		t.Fatalf("got %d gauges, want %d", len(spy.names), len(wantNames))
 	}
 	for i := range wantNames {
 		if spy.names[i] != wantNames[i] || spy.values[i] != wantVals[i] {
@@ -40,12 +28,12 @@ func TestEmitLagHistograms_notThrottled(t *testing.T) {
 	}
 }
 
-func TestEmitLagHistograms_throttled(t *testing.T) {
-	spy := &histogramSpy{}
-	EmitLagHistograms(spy, 4.0, 3.0, true)
+func TestEmitLagGauges_throttled(t *testing.T) {
+	spy := &gaugeSpy{}
+	EmitLagGauges(spy, 4.0, 3.0, true)
 
 	if len(spy.names) != 2 {
-		t.Fatalf("got %d histograms, want 2", len(spy.names))
+		t.Fatalf("got %d gauges, want 2", len(spy.names))
 	}
 	for i := range spy.names {
 		if len(spy.tags[i]) != 1 || spy.tags[i][0] != "throttled:true" {
@@ -54,6 +42,6 @@ func TestEmitLagHistograms_throttled(t *testing.T) {
 	}
 }
 
-func TestEmitLagHistograms_nilSafe(t *testing.T) {
-	EmitLagHistograms(nil, 1, 2, false)
+func TestEmitLagGauges_nilSafe(t *testing.T) {
+	EmitLagGauges(nil, 1, 2, false)
 }

--- a/go/metrics/lag_test.go
+++ b/go/metrics/lag_test.go
@@ -1,0 +1,59 @@
+/*
+   Copyright 2022 GitHub Inc.
+	 See https://github.com/github/gh-ost/blob/master/LICENSE
+*/
+
+package metrics
+
+import "testing"
+
+type histogramSpy struct {
+	names  []string
+	values []float64
+	tags   [][]string
+}
+
+func (s *histogramSpy) Histogram(name string, value float64, tags ...string) {
+	s.names = append(s.names, name)
+	s.values = append(s.values, value)
+	s.tags = append(s.tags, append([]string(nil), tags...))
+}
+
+func TestEmitLagHistograms_notThrottled(t *testing.T) {
+	spy := &histogramSpy{}
+	EmitLagHistograms(spy, 2.5, 1.25, false)
+
+	wantNames := []string{"lag.replication_seconds", "lag.heartbeat_seconds"}
+	wantVals := []float64{2.5, 1.25}
+	wantTags := []string{"throttled:false"}
+
+	if len(spy.names) != 2 {
+		t.Fatalf("got %d histograms, want 2", len(spy.names))
+	}
+	for i := range wantNames {
+		if spy.names[i] != wantNames[i] || spy.values[i] != wantVals[i] {
+			t.Fatalf("[%d] got %s=%v want %s=%v", i, spy.names[i], spy.values[i], wantNames[i], wantVals[i])
+		}
+		if len(spy.tags[i]) != 1 || spy.tags[i][0] != wantTags[0] {
+			t.Fatalf("[%d] got tags %v want [%s]", i, spy.tags[i], wantTags[0])
+		}
+	}
+}
+
+func TestEmitLagHistograms_throttled(t *testing.T) {
+	spy := &histogramSpy{}
+	EmitLagHistograms(spy, 4.0, 3.0, true)
+
+	if len(spy.names) != 2 {
+		t.Fatalf("got %d histograms, want 2", len(spy.names))
+	}
+	for i := range spy.names {
+		if len(spy.tags[i]) != 1 || spy.tags[i][0] != "throttled:true" {
+			t.Fatalf("[%d] got tags %v want [throttled:true]", i, spy.tags[i])
+		}
+	}
+}
+
+func TestEmitLagHistograms_nilSafe(t *testing.T) {
+	EmitLagHistograms(nil, 1, 2, false)
+}


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/1672
Closes: https://github.com/Shopify/schema-migrations/issues/5455

### Description

This PR adds both replica lag and heartbeat lag so dashboards can correlate throttling with the upstream cause.

This is done by adding a per status tick:

- `gh_ost.lag.replication_seconds` (histogram) — `migrationContext.GetCurrentLagDuration().Seconds()`
- `gh_ost.lag.heartbeat_seconds` (histogram) — `migrationContext.TimeSinceLastHeartbeatOnChangelog().Seconds()`

Tagged with `throttled:true|false`.

This results in some nice lag visualizations, which will indicate if gh-ost is throttled or not
<img width="1377" height="340" alt="Screenshot 2026-05-28 at 11 37 21 AM" src="https://github.com/user-attachments/assets/efaefad7-3217-4cc1-8bf9-c6cee915c49e" />


> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
