### PR TITLE
Emit throttle metrics

### DIFF
--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/github/gh-ost/go/base"
+	"github.com/github/gh-ost/go/metrics"
 	"github.com/github/gh-ost/go/mysql"
 	"github.com/github/gh-ost/go/sql"
 )
@@ -38,7 +39,10 @@ var (
 	}
 )
 
-const frenoMagicHint = "freno"
+const (
+	frenoMagicHint               = "freno"
+	throttleActiveMetricInterval = time.Second
+)
 
 // Throttler collects metrics related to throttling and makes informed decision
 // whether throttling should take place.
@@ -50,6 +54,10 @@ type Throttler struct {
 	httpClientTimeout time.Duration
 	inspector         *Inspector
 	finishedMigrating int64
+
+	throttleStartedAt     time.Time
+	throttleStartedReason string
+	throttleActiveEmitted time.Time
 }
 
 func NewThrottler(migrationContext *base.MigrationContext, applier *Applier, inspector *Inspector, appVersion string) *Throttler {
@@ -463,6 +471,32 @@ func (thlr *Throttler) initiateThrottlerCollection(firstThrottlingCollected chan
 	}()
 }
 
+func (thlr *Throttler) recordThrottleMetrics(alreadyThrottling bool, shouldThrottle bool, throttleReason string, now time.Time) {
+	throttleStateChanged := shouldThrottle != alreadyThrottling
+	shouldEmitActiveGauge := throttleStateChanged ||
+		thlr.throttleActiveEmitted.IsZero() ||
+		now.Sub(thlr.throttleActiveEmitted) >= throttleActiveMetricInterval
+	if shouldEmitActiveGauge {
+		metrics.EmitThrottleActiveGauge(thlr.migrationContext.Metrics, shouldThrottle)
+		thlr.throttleActiveEmitted = now
+	}
+
+	if shouldThrottle && !alreadyThrottling {
+		thlr.throttleStartedAt = now
+		thlr.throttleStartedReason = throttleReason
+		return
+	}
+	if alreadyThrottling && !shouldThrottle && !thlr.throttleStartedAt.IsZero() {
+		metrics.EmitThrottleInterval(
+			thlr.migrationContext.Metrics,
+			now.Sub(thlr.throttleStartedAt),
+			thlr.throttleStartedReason,
+		)
+		thlr.throttleStartedAt = time.Time{}
+		thlr.throttleStartedReason = ""
+	}
+}
+
 // initiateThrottlerChecks initiates the throttle ticker and sets the basic behavior of throttling.
 func (thlr *Throttler) initiateThrottlerChecks() {
 	throttlerFunction := func() {
@@ -478,6 +512,7 @@ func (thlr *Throttler) initiateThrottlerChecks() {
 			// End of throttling
 			thlr.applier.WriteAndLogChangelog("throttle", "done throttling")
 		}
+		thlr.recordThrottleMetrics(alreadyThrottling, shouldThrottle, throttleReason, time.Now())
 		thlr.migrationContext.SetThrottled(shouldThrottle, throttleReason, throttleReasonHint)
 	}
 	throttlerFunction()

--- a/go/logic/throttler_test.go
+++ b/go/logic/throttler_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/github/gh-ost/go/base"
 )
@@ -107,4 +108,54 @@ func TestThrottleCallsOnThrottledCallback(t *testing.T) {
 	case <-time.After(1 * time.Second):
 		t.Fatal("throttle() did not return after context cancellation")
 	}
+}
+
+type throttleMetricsSpy struct {
+	gaugeNames      []string
+	gaugeValues     []float64
+	histogramNames  []string
+	histogramValues []float64
+	countNames      []string
+	countValues     []int64
+	tags            [][]string
+}
+
+func (s *throttleMetricsSpy) Gauge(name string, value float64, tags ...string) {
+	s.gaugeNames = append(s.gaugeNames, name)
+	s.gaugeValues = append(s.gaugeValues, value)
+	s.tags = append(s.tags, append([]string(nil), tags...))
+}
+
+func (s *throttleMetricsSpy) Count(name string, value int64, tags ...string) {
+	s.countNames = append(s.countNames, name)
+	s.countValues = append(s.countValues, value)
+	s.tags = append(s.tags, append([]string(nil), tags...))
+}
+
+func (s *throttleMetricsSpy) Histogram(name string, value float64, tags ...string) {
+	s.histogramNames = append(s.histogramNames, name)
+	s.histogramValues = append(s.histogramValues, value)
+	s.tags = append(s.tags, append([]string(nil), tags...))
+}
+
+func TestRecordThrottleMetricsEmitsOneIntervalMetricOnThrottleExit(t *testing.T) {
+	thlr := newTestThrottler()
+	spy := &throttleMetricsSpy{}
+	thlr.migrationContext.Metrics = spy
+	startedAt := time.Unix(100, 0)
+
+	thlr.recordThrottleMetrics(false, true, "commanded by user", startedAt)
+	thlr.recordThrottleMetrics(true, true, "commanded by user", startedAt.Add(500*time.Millisecond))
+	thlr.recordThrottleMetrics(true, true, "commanded by user", startedAt.Add(1100*time.Millisecond))
+	thlr.recordThrottleMetrics(true, false, "", startedAt.Add(2500*time.Millisecond))
+
+	require.Equal(t, []string{"throttle.active", "throttle.active", "throttle.active"}, spy.gaugeNames)
+	require.Equal(t, []float64{1, 1, 0}, spy.gaugeValues)
+	require.Equal(t, []string{"throttle.duration_seconds"}, spy.histogramNames)
+	require.Equal(t, []float64{2.5}, spy.histogramValues)
+	require.Equal(t, []string{"throttle.events_total"}, spy.countNames)
+	require.Equal(t, []int64{1}, spy.countValues)
+	require.Len(t, spy.tags, 5)
+	assert.Equal(t, []string{"reason:commanded by user"}, spy.tags[3])
+	assert.Equal(t, []string{"reason:commanded by user"}, spy.tags[4])
 }

--- a/go/metrics/emit.go
+++ b/go/metrics/emit.go
@@ -106,3 +106,26 @@ func StartGoRuntimeReporter(ctx context.Context, client *Client, interval time.D
 		}
 	}()
 }
+
+// EmitThrottleActiveGauge emits whether throttling is currently active.
+func EmitThrottleActiveGauge(emit Emitter, active bool) {
+	if emit == nil {
+		return
+	}
+	if active {
+		emit.Gauge("throttle.active", 1)
+		return
+	}
+	emit.Gauge("throttle.active", 0)
+}
+
+// EmitThrottleInterval emits one event and one duration sample for a completed
+// throttled interval.
+func EmitThrottleInterval(emit Emitter, duration time.Duration, reason string) {
+	if emit == nil {
+		return
+	}
+	tags := []string{fmt.Sprintf("reason:%s", reason)}
+	emit.Histogram("throttle.duration_seconds", duration.Seconds(), tags...)
+	emit.Count("throttle.events_total", 1, tags...)
+}

--- a/go/metrics/emit_test.go
+++ b/go/metrics/emit_test.go
@@ -182,3 +182,77 @@ func TestStartGoRuntimeReporter_stopsOnCancel(t *testing.T) {
 	cancel()
 	time.Sleep(20 * time.Millisecond)
 }
+
+type throttleSpy struct {
+	gaugeNames      []string
+	gaugeValues     []float64
+	histogramNames  []string
+	histogramValues []float64
+	countNames      []string
+	countValues     []int64
+	tags            [][]string
+}
+
+func (s *throttleSpy) Gauge(name string, value float64, tags ...string) {
+	s.gaugeNames = append(s.gaugeNames, name)
+	s.gaugeValues = append(s.gaugeValues, value)
+	s.tags = append(s.tags, append([]string(nil), tags...))
+}
+
+func (s *throttleSpy) Count(name string, value int64, tags ...string) {
+	s.countNames = append(s.countNames, name)
+	s.countValues = append(s.countValues, value)
+	s.tags = append(s.tags, append([]string(nil), tags...))
+}
+
+func (s *throttleSpy) Histogram(name string, value float64, tags ...string) {
+	s.histogramNames = append(s.histogramNames, name)
+	s.histogramValues = append(s.histogramValues, value)
+	s.tags = append(s.tags, append([]string(nil), tags...))
+}
+
+func TestEmitThrottleActiveGauge(t *testing.T) {
+	spy := &throttleSpy{}
+
+	EmitThrottleActiveGauge(spy, true)
+	EmitThrottleActiveGauge(spy, false)
+
+	if len(spy.gaugeNames) != 2 {
+		t.Fatalf("got %d gauges, want 2", len(spy.gaugeNames))
+	}
+	if spy.gaugeNames[0] != "throttle.active" || spy.gaugeValues[0] != 1 {
+		t.Fatalf("got %s=%v, want throttle.active=1", spy.gaugeNames[0], spy.gaugeValues[0])
+	}
+	if spy.gaugeNames[1] != "throttle.active" || spy.gaugeValues[1] != 0 {
+		t.Fatalf("got %s=%v, want throttle.active=0", spy.gaugeNames[1], spy.gaugeValues[1])
+	}
+}
+
+func TestEmitThrottleInterval(t *testing.T) {
+	spy := &throttleSpy{}
+
+	EmitThrottleInterval(spy, 1500*time.Millisecond, "commanded by user")
+
+	if len(spy.histogramNames) != 1 {
+		t.Fatalf("got %d histograms, want 1", len(spy.histogramNames))
+	}
+	if spy.histogramNames[0] != "throttle.duration_seconds" || spy.histogramValues[0] != 1.5 {
+		t.Fatalf("got %s=%v, want throttle.duration_seconds=1.5", spy.histogramNames[0], spy.histogramValues[0])
+	}
+	if len(spy.countNames) != 1 {
+		t.Fatalf("got %d counts, want 1", len(spy.countNames))
+	}
+	if spy.countNames[0] != "throttle.events_total" || spy.countValues[0] != 1 {
+		t.Fatalf("got %s=%v, want throttle.events_total=1", spy.countNames[0], spy.countValues[0])
+	}
+	if len(spy.tags) != 2 || len(spy.tags[0]) != 1 || spy.tags[0][0] != "reason:commanded by user" ||
+		len(spy.tags[1]) != 1 || spy.tags[1][0] != "reason:commanded by user" {
+		t.Fatalf("got tags %v, want [reason:commanded by user]", spy.tags)
+	}
+}
+
+func TestEmitThrottleIntervalNilSafe(t *testing.T) {
+	EmitThrottleActiveGauge(nil, true)
+	EmitThrottleInterval(nil, time.Second, "test")
+	EmitThrottleInterval(&gaugeSpy{}, time.Second, "test")
+}


### PR DESCRIPTION
Related issue: https://github.com/github/gh-ost/issues/1672
Closes: https://github.com/Shopify/schema-migrations/issues/5456

### Description
- Emit `gh_ost.throttle.active` on each throttler check tick.
- Emit `gh_ost.throttle.duration_seconds` and `gh_ost.throttle.events_total` once per completed throttle interval.
- Tag interval metrics with the throttler reason, using the consolidated metrics emitter helper file from the parent PR.



# 🎩 
<img width="1037" height="309" alt="Screenshot 2026-06-02 at 9 59 10 PM" src="https://github.com/user-attachments/assets/103e3dfc-1ca0-4632-9681-17aeec3d4fa2" />



> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.

