### PR TITLE
Bump dev Go version to 1.25.9

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -6,7 +6,7 @@ env:
 
 up:
   - go:
-        version: "1.25.0"
+        version: "1.25.9"
   - podman
   - custom:
         name: Go Dependencies


### PR DESCRIPTION
Bump the Go version in dev.yml from 1.25.0 to 1.25.9 so local dev setup matches go.mod