### PR TITLE
Emit metrics related to binlog processing

### DIFF
--- a/go/binlog/binlog_dml_event.go
+++ b/go/binlog/binlog_dml_event.go
@@ -65,3 +65,17 @@ func NewBinlogDMLEvent(databaseName, tableName string, dml EventDML) *BinlogDMLE
 func (bde *BinlogDMLEvent) String() string {
 	return fmt.Sprintf("[%+v on %s:%s]", bde.DML, bde.DatabaseName, bde.TableName)
 }
+
+// EventTypeTag returns a lowercase DML type for metrics tags (insert/update/delete).
+func (dml EventDML) EventTypeTag() string {
+	return strings.ToLower(string(dml))
+}
+
+// RowsInRowsEvent returns the number of logical rows in a binlog rows event.
+// Update events encode two physical rows per logical row (before/after image).
+func RowsInRowsEvent(rowCount int, dml EventDML) int {
+	if dml == UpdateDML {
+		return rowCount / 2
+	}
+	return rowCount
+}

--- a/go/binlog/binlog_dml_event_test.go
+++ b/go/binlog/binlog_dml_event_test.go
@@ -1,0 +1,24 @@
+/*
+   Copyright 2026 GitHub Inc.
+	 See https://github.com/github/gh-ost/blob/master/LICENSE
+*/
+
+package binlog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRowsInRowsEvent(t *testing.T) {
+	require.Equal(t, 2, RowsInRowsEvent(2, InsertDML))
+	require.Equal(t, 1, RowsInRowsEvent(2, UpdateDML))
+	require.Equal(t, 3, RowsInRowsEvent(3, DeleteDML))
+}
+
+func TestEventTypeTag(t *testing.T) {
+	require.Equal(t, "insert", InsertDML.EventTypeTag())
+	require.Equal(t, "update", UpdateDML.EventTypeTag())
+	require.Equal(t, "delete", DeleteDML.EventTypeTag())
+}

--- a/go/binlog/gomysql_reader.go
+++ b/go/binlog/gomysql_reader.go
@@ -7,9 +7,11 @@ package binlog
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/github/gh-ost/go/base"
+	"github.com/github/gh-ost/go/metrics"
 	"github.com/github/gh-ost/go/mysql"
 	"github.com/github/gh-ost/go/sql"
 
@@ -50,6 +52,11 @@ type GoMySQLReader struct {
 	// LastTrxCoords are the coordinates of the last transaction completely read.
 	// If using the file coordinates it is binlog position of the transaction's XID event.
 	LastTrxCoords mysql.BinlogCoordinates
+
+	// Per-transaction counters for relevant (consumed) row events, flushed at transaction boundaries.
+	transactionRowEventTotal int64
+	transactionRowTotal      int64
+	previousLastCommitted    int64
 }
 
 func NewGoMySQLReader(migrationContext *base.MigrationContext, rowsEventFilters ...RowsEventFilterFunc) *GoMySQLReader {
@@ -110,12 +117,63 @@ func (gmr *GoMySQLReader) GetCurrentBinlogCoordinates() mysql.BinlogCoordinates 
 	return gmr.currentCoordinates.Clone()
 }
 
+func (gmr *GoMySQLReader) isRelevantTable(databaseName, tableName string) bool {
+	if !strings.EqualFold(databaseName, gmr.migrationContext.DatabaseName) {
+		return false
+	}
+	if strings.EqualFold(tableName, gmr.migrationContext.OriginalTableName) {
+		return true
+	}
+	return strings.EqualFold(tableName, gmr.migrationContext.GetChangelogTableName())
+}
+
+func (gmr *GoMySQLReader) flushTransactionMetrics() {
+	if gmr.transactionRowEventTotal == 0 {
+		return
+	}
+	emit := gmr.migrationContext.Metrics
+	metrics.RecordBinlogTransactionSize(emit, gmr.transactionRowEventTotal, gmr.transactionRowTotal)
+	gmr.transactionRowEventTotal = 0
+	gmr.transactionRowTotal = 0
+}
+
+func (gmr *GoMySQLReader) onGTIDEvent(event *replication.GTIDEvent) {
+	gmr.flushTransactionMetrics()
+
+	emit := gmr.migrationContext.Metrics
+	if event.TransactionLength > 0 {
+		metrics.RecordGTIDTransactionLengthBytes(emit, event.TransactionLength)
+	}
+	if event.LastCommitted != gmr.previousLastCommitted {
+		metrics.RecordUnfilteredCommitGroupSize(emit, float64(event.SequenceNumber-event.LastCommitted))
+	}
+	gmr.previousLastCommitted = event.LastCommitted
+}
+
 func (gmr *GoMySQLReader) handleRowsEvent(ev *replication.BinlogEvent, rowsEvent *replication.RowsEvent, entriesChannel chan<- *BinlogEntry) error {
 	currentCoords := gmr.GetCurrentBinlogCoordinates()
 	dml := ToEventDML(ev.Header.EventType.String())
 	if dml == NotDML {
 		return fmt.Errorf("unknown DML type: %s", ev.Header.EventType.String())
 	}
+
+	databaseName := string(rowsEvent.Table.Schema)
+	tableName := string(rowsEvent.Table.Table)
+	rowCount := int64(RowsInRowsEvent(len(rowsEvent.Rows), dml))
+	eventType := dml.EventTypeTag()
+	emit := gmr.migrationContext.Metrics
+	metrics.RecordBinlogRowsEventProcessed(emit, tableName, eventType, rowCount)
+	relevant := gmr.isRelevantTable(databaseName, tableName)
+	if !relevant {
+		metrics.RecordBinlogRowsEventFiltered(emit, tableName, eventType, rowCount)
+	} else {
+		metrics.RecordBinlogRowsEventConsumed(emit, tableName, eventType, rowCount)
+		metrics.RecordBinlogRowsInEvent(emit, tableName, rowCount)
+		gmr.transactionRowEventTotal++
+		gmr.transactionRowTotal += rowCount
+	}
+
+	beforeChannel := time.Now()
 	for i, row := range rowsEvent.Rows {
 		if dml == UpdateDML && i%2 == 1 {
 			// An update has two rows (WHERE+SET)
@@ -149,6 +207,9 @@ func (gmr *GoMySQLReader) handleRowsEvent(ev *replication.BinlogEvent, rowsEvent
 		// next iteration) or asynchronously (we keep pushing more events)
 		// In reality, reads will be synchronous
 		entriesChannel <- binlogEntry
+	}
+	if relevant {
+		metrics.RecordBinlogStreamerBlockedOnOutChannel(emit, time.Since(beforeChannel))
 	}
 	return nil
 }
@@ -185,6 +246,7 @@ func (gmr *GoMySQLReader) StreamEvents(canStopStreaming func() bool, entriesChan
 			if err != nil {
 				return err
 			}
+			gmr.onGTIDEvent(event)
 			gmr.currentCoordinatesMutex.Lock()
 			if gmr.LastTrxCoords != nil {
 				gmr.currentCoordinates = gmr.LastTrxCoords.Clone()
@@ -206,6 +268,9 @@ func (gmr *GoMySQLReader) StreamEvents(canStopStreaming func() bool, entriesChan
 			gmr.migrationContext.Log.Infof("rotate to next log from %s:%d to %s", coords.LogFile, int64(ev.Header.LogPos), event.NextLogName)
 			gmr.currentCoordinatesMutex.Unlock()
 		case *replication.XIDEvent:
+			if !gmr.migrationContext.UseGTIDs {
+				gmr.flushTransactionMetrics()
+			}
 			if gmr.migrationContext.UseGTIDs {
 				gmr.LastTrxCoords = &mysql.GTIDBinlogCoordinates{GTIDSet: event.GSet.(*gomysql.MysqlGTIDSet)}
 			} else {

--- a/go/metrics/emit.go
+++ b/go/metrics/emit.go
@@ -172,6 +172,84 @@ func cutOverOutcomeFromError(err error) string {
 	return CutOverOutcomeSuccess
 }
 
+// RecordBinlogRowsEventProcessed emits gh_ost.binlog_events and gh_ost.binlog_rows for a
+// rows event read from the binlog stream.
+func RecordBinlogRowsEventProcessed(emit Emitter, tableName, binlogEventType string, rowCount int64) {
+	if emit == nil || tableName == "" || binlogEventType == "" || rowCount < 0 {
+		return
+	}
+	tableTag := "table:" + tableName
+	eventTypeTag := "binlog_event_type:" + binlogEventType
+	emit.Count("binlog_events", 1, "type:processed", tableTag)
+	emit.Count("binlog_rows", rowCount, "type:processed", tableTag, eventTypeTag)
+}
+
+// RecordBinlogRowsEventFiltered emits gh_ost.binlog_events and gh_ost.binlog_rows for a
+// rows event on a table that is not being migrated.
+func RecordBinlogRowsEventFiltered(emit Emitter, tableName, binlogEventType string, rowCount int64) {
+	if emit == nil || tableName == "" || binlogEventType == "" || rowCount < 0 {
+		return
+	}
+	tableTag := "table:" + tableName
+	eventTypeTag := "binlog_event_type:" + binlogEventType
+	emit.Count("binlog_events", 1, "type:filtered", tableTag)
+	emit.Count("binlog_rows", rowCount, "type:filtered", tableTag, eventTypeTag)
+}
+
+// RecordBinlogRowsEventConsumed emits gh_ost.binlog_events and gh_ost.binlog_rows for a
+// rows event forwarded for application on a migrated table.
+func RecordBinlogRowsEventConsumed(emit Emitter, tableName, binlogEventType string, rowCount int64) {
+	if emit == nil || tableName == "" || binlogEventType == "" || rowCount < 0 {
+		return
+	}
+	tableTag := "table:" + tableName
+	eventTypeTag := "binlog_event_type:" + binlogEventType
+	emit.Count("binlog_events", 1, "type:consumed", tableTag, eventTypeTag)
+	emit.Count("binlog_rows", rowCount, "type:consumed", tableTag, eventTypeTag)
+}
+
+// RecordBinlogRowsInEvent emits gh_ost.binlog_rows_in_event for the row count in a forwarded event.
+func RecordBinlogRowsInEvent(emit Emitter, tableName string, rowCount int64) {
+	if emit == nil || tableName == "" || rowCount < 0 {
+		return
+	}
+	emit.Histogram("binlog_rows_in_event", float64(rowCount), "table:"+tableName)
+}
+
+// RecordBinlogTransactionSize emits row-event and row counts for a completed transaction
+// on relevant (consumed) tables.
+func RecordBinlogTransactionSize(emit Emitter, numRowEvents, numRows int64) {
+	if emit == nil || numRowEvents <= 0 || numRows < 0 {
+		return
+	}
+	emit.Histogram("transaction_num_row_events", float64(numRowEvents))
+	emit.Histogram("transaction_num_rows", float64(numRows))
+}
+
+// RecordGTIDTransactionLengthBytes emits the transaction length from a GTID event (MySQL 8.0.2+).
+func RecordGTIDTransactionLengthBytes(emit Emitter, length uint64) {
+	if emit == nil || length == 0 {
+		return
+	}
+	emit.Histogram("gtid_event_transaction_length_bytes", float64(length))
+}
+
+// RecordUnfilteredCommitGroupSize emits the parallel replication commit group size from a GTID event.
+func RecordUnfilteredCommitGroupSize(emit Emitter, size float64) {
+	if emit == nil || size < 0 {
+		return
+	}
+	emit.Gauge("unfiltered_commit_group_size", size)
+}
+
+// RecordBinlogStreamerBlockedOnOutChannel emits time spent blocked sending rows to the events channel.
+func RecordBinlogStreamerBlockedOnOutChannel(emit Emitter, d time.Duration) {
+	if emit == nil || d < 0 {
+		return
+	}
+	emit.Histogram("binlog_streamer_blocked_on_out_channel_ms", float64(d.Milliseconds()))
+}
+
 // RecordSleep emits per-stage sleep/wait metrics (namespace is applied by the client):
 // gh_ost.sleep.duration_milliseconds and gh_ost.sleep.total_milliseconds, both tagged by stage.
 func RecordSleep(emit Emitter, stage string, d time.Duration) {

--- a/go/metrics/emit_test.go
+++ b/go/metrics/emit_test.go
@@ -428,6 +428,29 @@ func TestRecordSleepNilSafe(t *testing.T) {
 	RecordSleep(&sleepSpy{}, "retry_backoff", -time.Second)
 }
 
+type histogramCountSpy struct {
+	histogramNames  []string
+	histogramValues []float64
+	histogramTags   [][]string
+	countNames      []string
+	countValues     []int64
+	countTags       [][]string
+}
+
+func (s *histogramCountSpy) Gauge(_ string, _ float64, _ ...string) {}
+
+func (s *histogramCountSpy) Histogram(name string, value float64, tags ...string) {
+	s.histogramNames = append(s.histogramNames, name)
+	s.histogramValues = append(s.histogramValues, value)
+	s.histogramTags = append(s.histogramTags, append([]string(nil), tags...))
+}
+
+func (s *histogramCountSpy) Count(name string, value int64, tags ...string) {
+	s.countNames = append(s.countNames, name)
+	s.countValues = append(s.countValues, value)
+	s.countTags = append(s.countTags, append([]string(nil), tags...))
+}
+
 func TestRecordBinlogRowsEventMetrics(t *testing.T) {
 	spy := &histogramCountSpy{}
 

--- a/go/metrics/emit_test.go
+++ b/go/metrics/emit_test.go
@@ -319,19 +319,26 @@ func TestRecordCutOverMetricsNilSafe(t *testing.T) {
 }
 
 type histogramSpy struct {
-	names  []string
-	values []float64
-	tags   [][]string
+	names       []string
+	values      []float64
+	tags        [][]string
+	countNames  []string
+	countValues []int64
+	countTags   [][]string
 }
 
 func (h *histogramSpy) Gauge(_ string, _ float64, _ ...string) {}
 
-func (h *histogramSpy) Count(_ string, _ int64, _ ...string) {}
+func (h *histogramSpy) Count(name string, value int64, tags ...string) {
+	h.countNames = append(h.countNames, name)
+	h.countValues = append(h.countValues, value)
+	h.countTags = append(h.countTags, append([]string(nil), tags...))
+}
 
 func (h *histogramSpy) Histogram(name string, value float64, tags ...string) {
 	h.names = append(h.names, name)
 	h.values = append(h.values, value)
-	h.tags = append(h.tags, tags)
+	h.tags = append(h.tags, append([]string(nil), tags...))
 }
 
 func TestRecordQueryDuration(t *testing.T) {
@@ -428,31 +435,8 @@ func TestRecordSleepNilSafe(t *testing.T) {
 	RecordSleep(&sleepSpy{}, "retry_backoff", -time.Second)
 }
 
-type histogramCountSpy struct {
-	histogramNames  []string
-	histogramValues []float64
-	histogramTags   [][]string
-	countNames      []string
-	countValues     []int64
-	countTags       [][]string
-}
-
-func (s *histogramCountSpy) Gauge(_ string, _ float64, _ ...string) {}
-
-func (s *histogramCountSpy) Histogram(name string, value float64, tags ...string) {
-	s.histogramNames = append(s.histogramNames, name)
-	s.histogramValues = append(s.histogramValues, value)
-	s.histogramTags = append(s.histogramTags, append([]string(nil), tags...))
-}
-
-func (s *histogramCountSpy) Count(name string, value int64, tags ...string) {
-	s.countNames = append(s.countNames, name)
-	s.countValues = append(s.countValues, value)
-	s.countTags = append(s.countTags, append([]string(nil), tags...))
-}
-
 func TestRecordBinlogRowsEventMetrics(t *testing.T) {
-	spy := &histogramCountSpy{}
+	spy := &histogramSpy{}
 
 	RecordBinlogRowsEventProcessed(spy, "orders", "insert", 3)
 	RecordBinlogRowsEventFiltered(spy, "other_table", "update", 2)
@@ -482,24 +466,24 @@ func TestRecordBinlogRowsEventMetrics(t *testing.T) {
 			t.Fatalf("[%d] got tags %#v, want %#v", i, spy.countTags[i], want.tags)
 		}
 	}
-	if len(spy.histogramNames) != 1 || spy.histogramNames[0] != "binlog_rows_in_event" || spy.histogramValues[0] != 1 {
-		t.Fatalf("got histogram %#v values %#v", spy.histogramNames, spy.histogramValues)
+	if len(spy.names) != 1 || spy.names[0] != "binlog_rows_in_event" || spy.values[0] != 1 {
+		t.Fatalf("got histogram %#v values %#v", spy.names, spy.values)
 	}
-	if !slices.Equal(spy.histogramTags[0], []string{"table:orders"}) {
-		t.Fatalf("got histogram tags %#v", spy.histogramTags[0])
+	if !slices.Equal(spy.tags[0], []string{"table:orders"}) {
+		t.Fatalf("got histogram tags %#v", spy.tags[0])
 	}
 }
 
 func TestRecordBinlogRowsEventMetricsNilSafe(t *testing.T) {
 	RecordBinlogRowsEventProcessed(nil, "orders", "insert", 1)
-	RecordBinlogRowsEventFiltered(&histogramCountSpy{}, "", "insert", 1)
-	RecordBinlogRowsEventConsumed(&histogramCountSpy{}, "orders", "", 1)
-	RecordBinlogRowsInEvent(&histogramCountSpy{}, "", 1)
-	RecordBinlogRowsInEvent(&histogramCountSpy{}, "orders", -1)
+	RecordBinlogRowsEventFiltered(&histogramSpy{}, "", "insert", 1)
+	RecordBinlogRowsEventConsumed(&histogramSpy{}, "orders", "", 1)
+	RecordBinlogRowsInEvent(&histogramSpy{}, "", 1)
+	RecordBinlogRowsInEvent(&histogramSpy{}, "orders", -1)
 }
 
 func TestRecordBinlogTransactionMetrics(t *testing.T) {
-	spy := &histogramCountSpy{}
+	spy := &histogramSpy{}
 	gaugeSpy := &gaugeSpy{}
 
 	RecordBinlogTransactionSize(spy, 3, 10)
@@ -507,8 +491,8 @@ func TestRecordBinlogTransactionMetrics(t *testing.T) {
 	RecordUnfilteredCommitGroupSize(gaugeSpy, 5)
 	RecordBinlogStreamerBlockedOnOutChannel(spy, 25*time.Millisecond)
 
-	if len(spy.histogramNames) != 4 {
-		t.Fatalf("got %d histograms, want 4: %#v", len(spy.histogramNames), spy.histogramNames)
+	if len(spy.names) != 4 {
+		t.Fatalf("got %d histograms, want 4: %#v", len(spy.names), spy.names)
 	}
 	wantHistograms := []struct {
 		name  string
@@ -520,8 +504,8 @@ func TestRecordBinlogTransactionMetrics(t *testing.T) {
 		{"binlog_streamer_blocked_on_out_channel_ms", 25},
 	}
 	for i, want := range wantHistograms {
-		if spy.histogramNames[i] != want.name || spy.histogramValues[i] != want.value {
-			t.Fatalf("[%d] got %s=%v, want %s=%v", i, spy.histogramNames[i], spy.histogramValues[i], want.name, want.value)
+		if spy.names[i] != want.name || spy.values[i] != want.value {
+			t.Fatalf("[%d] got %s=%v, want %s=%v", i, spy.names[i], spy.values[i], want.name, want.value)
 		}
 	}
 	if len(gaugeSpy.names) != 1 || gaugeSpy.names[0] != "unfiltered_commit_group_size" || gaugeSpy.values[0] != 5 {
@@ -531,11 +515,11 @@ func TestRecordBinlogTransactionMetrics(t *testing.T) {
 
 func TestRecordBinlogTransactionMetricsNilSafe(t *testing.T) {
 	RecordBinlogTransactionSize(nil, 1, 1)
-	RecordBinlogTransactionSize(&histogramCountSpy{}, 0, 1)
+	RecordBinlogTransactionSize(&histogramSpy{}, 0, 1)
 	RecordGTIDTransactionLengthBytes(nil, 100)
-	RecordGTIDTransactionLengthBytes(&histogramCountSpy{}, 0)
+	RecordGTIDTransactionLengthBytes(&histogramSpy{}, 0)
 	RecordUnfilteredCommitGroupSize(nil, 1)
 	RecordUnfilteredCommitGroupSize(&gaugeSpy{}, -1)
 	RecordBinlogStreamerBlockedOnOutChannel(nil, time.Second)
-	RecordBinlogStreamerBlockedOnOutChannel(&histogramCountSpy{}, -time.Second)
+	RecordBinlogStreamerBlockedOnOutChannel(&histogramSpy{}, -time.Second)
 }

--- a/go/metrics/emit_test.go
+++ b/go/metrics/emit_test.go
@@ -427,3 +427,92 @@ func TestRecordSleepNilSafe(t *testing.T) {
 	RecordSleep(&sleepSpy{}, "", time.Second)
 	RecordSleep(&sleepSpy{}, "retry_backoff", -time.Second)
 }
+
+func TestRecordBinlogRowsEventMetrics(t *testing.T) {
+	spy := &histogramCountSpy{}
+
+	RecordBinlogRowsEventProcessed(spy, "orders", "insert", 3)
+	RecordBinlogRowsEventFiltered(spy, "other_table", "update", 2)
+	RecordBinlogRowsEventConsumed(spy, "orders", "delete", 1)
+	RecordBinlogRowsInEvent(spy, "orders", 1)
+
+	wantCounts := []struct {
+		name  string
+		value int64
+		tags  []string
+	}{
+		{"binlog_events", 1, []string{"type:processed", "table:orders"}},
+		{"binlog_rows", 3, []string{"type:processed", "table:orders", "binlog_event_type:insert"}},
+		{"binlog_events", 1, []string{"type:filtered", "table:other_table"}},
+		{"binlog_rows", 2, []string{"type:filtered", "table:other_table", "binlog_event_type:update"}},
+		{"binlog_events", 1, []string{"type:consumed", "table:orders", "binlog_event_type:delete"}},
+		{"binlog_rows", 1, []string{"type:consumed", "table:orders", "binlog_event_type:delete"}},
+	}
+	if len(spy.countNames) != len(wantCounts) {
+		t.Fatalf("got %d counts, want %d", len(spy.countNames), len(wantCounts))
+	}
+	for i, want := range wantCounts {
+		if spy.countNames[i] != want.name || spy.countValues[i] != want.value {
+			t.Fatalf("[%d] got %s=%d, want %s=%d", i, spy.countNames[i], spy.countValues[i], want.name, want.value)
+		}
+		if !slices.Equal(spy.countTags[i], want.tags) {
+			t.Fatalf("[%d] got tags %#v, want %#v", i, spy.countTags[i], want.tags)
+		}
+	}
+	if len(spy.histogramNames) != 1 || spy.histogramNames[0] != "binlog_rows_in_event" || spy.histogramValues[0] != 1 {
+		t.Fatalf("got histogram %#v values %#v", spy.histogramNames, spy.histogramValues)
+	}
+	if !slices.Equal(spy.histogramTags[0], []string{"table:orders"}) {
+		t.Fatalf("got histogram tags %#v", spy.histogramTags[0])
+	}
+}
+
+func TestRecordBinlogRowsEventMetricsNilSafe(t *testing.T) {
+	RecordBinlogRowsEventProcessed(nil, "orders", "insert", 1)
+	RecordBinlogRowsEventFiltered(&histogramCountSpy{}, "", "insert", 1)
+	RecordBinlogRowsEventConsumed(&histogramCountSpy{}, "orders", "", 1)
+	RecordBinlogRowsInEvent(&histogramCountSpy{}, "", 1)
+	RecordBinlogRowsInEvent(&histogramCountSpy{}, "orders", -1)
+}
+
+func TestRecordBinlogTransactionMetrics(t *testing.T) {
+	spy := &histogramCountSpy{}
+	gaugeSpy := &gaugeSpy{}
+
+	RecordBinlogTransactionSize(spy, 3, 10)
+	RecordGTIDTransactionLengthBytes(spy, 4096)
+	RecordUnfilteredCommitGroupSize(gaugeSpy, 5)
+	RecordBinlogStreamerBlockedOnOutChannel(spy, 25*time.Millisecond)
+
+	if len(spy.histogramNames) != 4 {
+		t.Fatalf("got %d histograms, want 4: %#v", len(spy.histogramNames), spy.histogramNames)
+	}
+	wantHistograms := []struct {
+		name  string
+		value float64
+	}{
+		{"transaction_num_row_events", 3},
+		{"transaction_num_rows", 10},
+		{"gtid_event_transaction_length_bytes", 4096},
+		{"binlog_streamer_blocked_on_out_channel_ms", 25},
+	}
+	for i, want := range wantHistograms {
+		if spy.histogramNames[i] != want.name || spy.histogramValues[i] != want.value {
+			t.Fatalf("[%d] got %s=%v, want %s=%v", i, spy.histogramNames[i], spy.histogramValues[i], want.name, want.value)
+		}
+	}
+	if len(gaugeSpy.names) != 1 || gaugeSpy.names[0] != "unfiltered_commit_group_size" || gaugeSpy.values[0] != 5 {
+		t.Fatalf("got gauge %#v values %#v", gaugeSpy.names, gaugeSpy.values)
+	}
+}
+
+func TestRecordBinlogTransactionMetricsNilSafe(t *testing.T) {
+	RecordBinlogTransactionSize(nil, 1, 1)
+	RecordBinlogTransactionSize(&histogramCountSpy{}, 0, 1)
+	RecordGTIDTransactionLengthBytes(nil, 100)
+	RecordGTIDTransactionLengthBytes(&histogramCountSpy{}, 0)
+	RecordUnfilteredCommitGroupSize(nil, 1)
+	RecordUnfilteredCommitGroupSize(&gaugeSpy{}, -1)
+	RecordBinlogStreamerBlockedOnOutChannel(nil, time.Second)
+	RecordBinlogStreamerBlockedOnOutChannel(&histogramCountSpy{}, -time.Second)
+}


### PR DESCRIPTION
Related issue: https://github.com/Shopify/schema-migrations/issues/5838

### Description

This PR adds metrics around binlog processing so we can see what gh-ost is reading, forwarding, and filtering while streaming row events. Metrics follow similar patterns as [backfilter](https://github.com/Shopify/backfilter)'s binlog tailer/reader.

| Metric | Type | Tags | When |
|--------|------|------|------|
| `binlog_events` | count | `type:processed`, `table:<name>` | Every rows event read from the binlog |
| `binlog_rows` | count | `type:processed`, `table:<name>`, `binlog_event_type:insert\|update\|delete` | Same |
| `binlog_events` | count | `type:filtered`, `table:<name>` | Rows event on a table that is not the migration table or changelog table |
| `binlog_rows` | count | `type:filtered`, `table:<name>`, `binlog_event_type:...` | Same |
| `binlog_events` | count | `type:consumed`, `table:<name>`, `binlog_event_type:...` | Rows event on the original table or `_ghc` changelog table |
| `binlog_rows` | count | `type:consumed`, `table:<name>`, `binlog_event_type:...` | Same |
| `binlog_rows_in_event` | histogram | `table:<name>` | Row count per consumed rows event |
| `transaction_num_row_events` | histogram | — | End of transaction: consumed row events on relevant tables (flush on next GTID, or on XID in file-position mode) |
| `transaction_num_rows` | histogram | — | End of transaction: logical rows in those consumed events |
| `gtid_event_transaction_length_bytes` | histogram | — | Each GTID event (`TransactionLength`, MySQL 8.0.2+) |
| `unfiltered_commit_group_size` | gauge | — | When `LastCommitted` changes (`SequenceNumber - LastCommitted`) |
| `binlog_streamer_blocked_on_out_channel_ms` | histogram | — | Time blocked sending a consumed rows event to the events channel |

<img width="1485" height="716" alt="Screenshot 2026-07-14 at 3 02 52 PM" src="https://github.com/user-attachments/assets/ed46b26f-54aa-4315-8541-03076d8c6b76" />


> In case this PR introduced Go code changes:

- [x] contributed code is using same conventions as original code
- [x] `script/cibuild` returns with no formatting errors, build errors or unit test errors.